### PR TITLE
refactor: centralize configuration constants in shared module

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -13,7 +13,7 @@ def main(input_text, ref_audio_path, ref_text, backbone, output_path="output.wav
         backbone_repo=backbone,
         backbone_device="cpu",
         codec_repo="neuphonic/neucodec",
-        codec_device="cpu"
+        codec_device="cpu",
     )
 
     # Check if ref_text is a path if it is read it if not just return string
@@ -37,34 +37,25 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="NeuTTSAir Example")
     parser.add_argument(
-        "--input_text", 
-        type=str, 
-        required=True, 
-        help="Input text to be converted to speech"
+        "--input_text", type=str, required=True, help="Input text to be converted to speech"
     )
     parser.add_argument(
-        "--ref_audio", 
-        type=str, 
-        default="./samples/dave.wav", 
-        help="Path to reference audio file"
+        "--ref_audio", type=str, default="./samples/dave.wav", help="Path to reference audio file"
     )
     parser.add_argument(
         "--ref_text",
         type=str,
-        default="./samples/dave.txt", 
+        default="./samples/dave.txt",
         help="Reference text corresponding to the reference audio",
     )
     parser.add_argument(
-        "--output_path", 
-        type=str, 
-        default="output.wav", 
-        help="Path to save the output audio"
+        "--output_path", type=str, default="output.wav", help="Path to save the output audio"
     )
     parser.add_argument(
-        "--backbone", 
-        type=str, 
-        default="neuphonic/neutts-air", 
-        help="Huggingface repo containing the backbone checkpoint"
+        "--backbone",
+        type=str,
+        default="neuphonic/neutts-air",
+        help="Huggingface repo containing the backbone checkpoint",
     )
     args = parser.parse_args()
     main(

--- a/examples/onnx_example.py
+++ b/examples/onnx_example.py
@@ -1,6 +1,9 @@
 import os
+from pathlib import Path
+
 import soundfile as sf
 import torch
+import numpy as np
 from neuttsair.neutts import NeuTTSAir
 
 
@@ -14,7 +17,7 @@ def main(input_text, ref_codes_path, ref_text, backbone, output_path="output.wav
         backbone_repo=backbone,
         backbone_device="cpu",
         codec_repo="neuphonic/neucodec-onnx-decoder",
-        codec_device="cpu"
+        codec_device="cpu",
     )
 
     # Check if ref_text is a path if it is read it if not just return string
@@ -23,7 +26,9 @@ def main(input_text, ref_codes_path, ref_text, backbone, output_path="output.wav
             ref_text = f.read().strip()
 
     if ref_codes_path and os.path.exists(ref_codes_path):
-        ref_codes = torch.load(ref_codes_path)
+        ref_codes = _load_ref_codes(ref_codes_path)
+    else:
+        raise FileNotFoundError(f"Reference codes not found: {ref_codes_path}")
 
     print(f"Generating audio for input text: {input_text}")
     wav = tts.infer(input_text, ref_codes, ref_text)
@@ -38,34 +43,34 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="NeuTTSAir Example")
     parser.add_argument(
-        "--input_text", 
-        type=str, 
-        required=True, 
-        help="Input text to be converted to speech"
+        "--input_text",
+        type=str,
+        required=True,
+        help="Input text to be converted to speech",
     )
     parser.add_argument(
-        "--ref_codes", 
-        type=str, 
-        default="./samples/dave.pt", 
-        help="Path to pre-encoded reference audio"
+        "--ref_codes",
+        type=str,
+        default="./samples/dave.pt",
+        help="Path to pre-encoded reference audio",
     )
     parser.add_argument(
         "--ref_text",
         type=str,
-        default="./samples/dave.txt", 
+        default="./samples/dave.txt",
         help="Reference text corresponding to the reference audio",
     )
     parser.add_argument(
-        "--output_path", 
-        type=str, 
-        default="output.wav", 
-        help="Path to save the output audio"
+        "--output_path",
+        type=str,
+        default="output.wav",
+        help="Path to save the output audio",
     )
     parser.add_argument(
-        "--backbone", 
-        type=str, 
-        default="neuphonic/neutts-air", 
-        help="Huggingface repo containing the backbone checkpoint"
+        "--backbone",
+        type=str,
+        default="neuphonic/neutts-air",
+        help="Huggingface repo containing the backbone checkpoint",
     )
     args = parser.parse_args()
     main(
@@ -75,3 +80,32 @@ if __name__ == "__main__":
         backbone=args.backbone,
         output_path=args.output_path,
     )
+
+
+def _load_ref_codes(ref_codes_path: str):
+    path = Path(ref_codes_path)
+    suffix = path.suffix.lower()
+
+    if suffix in {".pt", ".pth"}:
+        try:
+            data = torch.load(path, map_location="cpu", weights_only=True)
+        except TypeError as exc:
+            raise RuntimeError(
+                "Loading '.pt' reference codes requires torch >= 2.0 with weights_only support "
+                "to avoid executing arbitrary pickle payloads."
+            ) from exc
+    elif suffix == ".npy":
+        data = np.load(path, allow_pickle=False)
+    else:
+        raise ValueError(
+            f"Unsupported reference code format '{path.suffix}'. Expected .pt, .pth, or .npy"
+        )
+
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu().view(-1).tolist()
+    if isinstance(data, np.ndarray):
+        return data.reshape(-1).tolist()
+    if isinstance(data, (list, tuple)):
+        return [int(val) for val in data]
+
+    raise ValueError("Reference code file must contain tensor-like data.")

--- a/examples/wyoming_server.py
+++ b/examples/wyoming_server.py
@@ -1,0 +1,406 @@
+import argparse
+import asyncio
+import logging
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+import torch
+
+from neuttsair.neutts import NeuTTSAir
+from wyoming.audio import AudioChunk, AudioStart, AudioStop
+from wyoming.error import Error
+from wyoming.event import Event
+from wyoming.info import Attribution, Describe, Info, TtsProgram, TtsVoice
+from wyoming.server import AsyncEventHandler, AsyncServer
+from wyoming.tts import Synthesize, SynthesizeVoice
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class VoiceProfile:
+    """Represents a cloned voice that can be served over Wyoming."""
+
+    name: str
+    ref_codes: List[int]
+    ref_text: str
+    description: Optional[str] = None
+    language: str = "en"
+
+    def to_tts_voice(self, attribution: Attribution) -> TtsVoice:
+        return TtsVoice(
+            name=self.name,
+            description=self.description or f"NeuTTSAir voice '{self.name}'",
+            attribution=attribution,
+            installed=True,
+            version=None,
+            languages=[self.language],
+        )
+
+
+class NeuTTSAirEventHandler(AsyncEventHandler):
+    """Handles incoming Wyoming events for NeuTTSAir."""
+
+    def __init__(
+        self,
+        tts: NeuTTSAir,
+        voice_map: Dict[str, VoiceProfile],
+        default_voice: str,
+        info_event: Event,
+        chunk_size: int,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._tts = tts
+        self._voices = voice_map
+        self._default_voice = default_voice
+        self._info_event = info_event
+        self._chunk_size = max(1, chunk_size)
+        self._sample_rate = self._tts.sample_rate
+
+    async def handle_event(self, event: Event) -> bool:
+        if event is None:
+            return False
+
+        if Describe.is_type(event.type):
+            await self.write_event(self._info_event)
+            LOGGER.debug("Provided Wyoming info to client")
+            return True
+
+        if event.type != "synthesize":
+            LOGGER.debug("Ignoring unsupported event type: %s", event.type)
+            return True
+
+        synthesize = Synthesize.from_event(event)
+        voice = self._select_voice(synthesize.voice)
+        if voice is None:
+            await self.write_event(
+                Error(
+                    text="Requested voice not available",
+                    code="voice-not-found",
+                ).event()
+            )
+            return True
+
+        LOGGER.info("Synthesizing text with voice '%s'", voice.name)
+
+        try:
+            wav = await asyncio.to_thread(
+                self._tts.infer,
+                synthesize.text,
+                voice.ref_codes,
+                voice.ref_text,
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.exception("Failed to synthesize audio")
+            await self.write_event(
+                Error(
+                    text=str(err),
+                    code=type(err).__name__,
+                ).event()
+            )
+            return True
+
+        await self._stream_audio(wav)
+        return True
+
+    def _select_voice(self, request_voice: Optional[SynthesizeVoice]) -> Optional[VoiceProfile]:
+        if request_voice is not None:
+            if request_voice.name and request_voice.name in self._voices:
+                return self._voices[request_voice.name]
+
+            if request_voice.language:
+                for voice in self._voices.values():
+                    if voice.language == request_voice.language:
+                        return voice
+
+        return self._voices.get(self._default_voice)
+
+    async def _stream_audio(self, wav: np.ndarray | torch.Tensor) -> None:
+        audio_bytes = _to_pcm16_bytes(wav)
+        bytes_per_sample = 2  # int16 mono
+        chunk_bytes = self._chunk_size * bytes_per_sample
+
+        await self.write_event(AudioStart(rate=self._sample_rate, width=2, channels=1).event())
+
+        for chunk in _chunk_bytes(audio_bytes, chunk_bytes):
+            await self.write_event(
+                AudioChunk(
+                    rate=self._sample_rate,
+                    width=2,
+                    channels=1,
+                    audio=chunk,
+                ).event()
+            )
+
+        await self.write_event(AudioStop().event())
+
+
+def _chunk_bytes(data: bytes, chunk_size: int) -> Iterable[bytes]:
+    if chunk_size <= 0:
+        yield data
+        return
+
+    data_len = len(data)
+    for idx in range(0, data_len, chunk_size):
+        end = idx + chunk_size
+        yield data[idx:end]
+
+
+def _to_pcm16_bytes(audio: np.ndarray | torch.Tensor) -> bytes:
+    if isinstance(audio, torch.Tensor):
+        audio = audio.detach().cpu().numpy()
+
+    if not isinstance(audio, np.ndarray):
+        audio = np.asarray(audio)
+
+    audio = audio.flatten()
+    audio = np.clip(audio, -1.0, 1.0)
+    pcm = (audio * np.iinfo(np.int16).max).astype("<i2")
+    return pcm.tobytes()
+
+
+def _parse_voice_arg(raw: str) -> Dict[str, str]:
+    parts = {}
+    for section in raw.split(","):
+        section = section.strip()
+        if not section:
+            continue
+        if "=" not in section:
+            message = (
+                "Voice definition '{raw}' must use key=value pairs " "separated by commas"
+            ).format(raw=raw)
+            raise ValueError(message)
+        key, value = section.split("=", 1)
+        parts[key.strip()] = value.strip()
+
+    required = {"name", "ref_text"}
+    if not required.issubset(parts):
+        missing = ", ".join(sorted(required - set(parts)))
+        message = f"Voice definition missing required fields: {missing}"
+        raise ValueError(message)
+
+    if ("ref_audio" not in parts) and ("ref_codes" not in parts):
+        message = " ".join(
+            [
+                "Voice definition must include either 'ref_audio'",
+                "or 'ref_codes'",
+            ]
+        )
+        raise ValueError(message)
+
+    return parts
+
+
+def _flatten_codes(
+    codes: np.ndarray | torch.Tensor | Iterable[int],
+) -> List[int]:
+    if isinstance(codes, torch.Tensor):
+        codes = codes.detach().cpu().view(-1).tolist()
+    elif isinstance(codes, np.ndarray):
+        codes = codes.reshape(-1).tolist()
+    else:
+        codes = list(codes)
+
+    return [int(code) for code in codes]
+
+
+def _load_ref_codes(path: Path) -> List[int]:
+    suffix = path.suffix.lower()
+    if suffix in {".pt", ".pth"}:
+        try:
+            data = torch.load(path, map_location="cpu", weights_only=True)
+        except TypeError:  # Fallback for older torch without weights_only
+            raise RuntimeError(
+                "Loading '.pt' reference codes requires torch >= 2.0 with weights_only support "
+                "to avoid executing arbitrary pickle payloads."
+            ) from None
+    elif suffix == ".npy":
+        data = np.load(path, allow_pickle=False)
+    else:
+        message = (
+            "Unsupported reference code format '{suffix}'. Expected " ".pt, .pth, or .npy"
+        ).format(suffix=path.suffix)
+        raise ValueError(message)
+
+    if not isinstance(data, (torch.Tensor, np.ndarray, list, tuple)):
+        message = "Reference code file must contain tensor-like data."
+        raise ValueError(message)
+
+    return _flatten_codes(data)
+
+
+def _load_voice_profiles(
+    tts: NeuTTSAir,
+    voice_args: List[str],
+) -> List[VoiceProfile]:
+    voices: List[VoiceProfile] = []
+
+    for raw_voice in voice_args:
+        config = _parse_voice_arg(raw_voice)
+        name = config["name"]
+
+        ref_text_value = config["ref_text"]
+        ref_text_path = Path(ref_text_value)
+        if ref_text_path.is_file():
+            text_data = ref_text_path.read_text(encoding="utf-8")
+            ref_text = text_data.strip()
+        else:
+            ref_text = ref_text_value
+
+        if "ref_codes" in config:
+            ref_codes_path = Path(config["ref_codes"])
+            if not ref_codes_path.is_file():
+                message = f"Reference codes not found: {ref_codes_path}"
+                raise FileNotFoundError(message)
+
+            ref_codes = _load_ref_codes(ref_codes_path)
+        else:
+            ref_audio_path = Path(config["ref_audio"])
+            if not ref_audio_path.is_file():
+                message = f"Reference audio not found: {ref_audio_path}"
+                raise FileNotFoundError(message)
+
+            audio_path = str(ref_audio_path)
+            ref_codes_tensor = tts.encode_reference(audio_path)
+            ref_codes = _flatten_codes(ref_codes_tensor)
+
+        description = config.get("description")
+        language = config.get("language", "en")
+
+        voices.append(
+            VoiceProfile(
+                name=name,
+                ref_codes=ref_codes,
+                ref_text=ref_text,
+                description=description,
+                language=language,
+            )
+        )
+
+        LOGGER.info("Loaded voice '%s'", name)
+
+    return voices
+
+
+async def _run_server(args: argparse.Namespace) -> None:
+    tts = NeuTTSAir(
+        backbone_repo=args.backbone,
+        backbone_device=args.backbone_device,
+        codec_repo=args.codec,
+        codec_device=args.codec_device,
+    )
+
+    voices = _load_voice_profiles(tts, args.voice)
+    if not voices:
+        raise ValueError("At least one voice definition is required")
+
+    voice_map = {voice.name: voice for voice in voices}
+    default_voice = voices[0].name
+
+    program_attribution = Attribution(
+        name="Neuphonic",
+        url="https://neuphonic.com/",
+    )
+    tts_program_voices: List[TtsVoice] = []
+    for voice in voices:
+        program_voice = voice.to_tts_voice(program_attribution)
+        tts_program_voices.append(program_voice)
+
+    wyoming_info = Info(
+        tts=[
+            TtsProgram(
+                name="neutts-air",
+                description="NeuTTSAir neural text to speech",
+                attribution=program_attribution,
+                installed=True,
+                voices=tts_program_voices,
+                version=None,
+                supports_synthesize_streaming=False,
+            )
+        ]
+    )
+
+    server = AsyncServer.from_uri(args.uri)
+    log_message = "NeuTTSAir Wyoming server listening on %s"
+    LOGGER.info(log_message, args.uri)
+    await server.run(
+        partial(
+            NeuTTSAirEventHandler,
+            tts,
+            voice_map,
+            default_voice,
+            wyoming_info.event(),
+            args.chunk_size,
+        )
+    )
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Expose NeuTTSAir as a Wyoming TTS service")
+    parser.add_argument(
+        "--uri",
+        default="tcp://0.0.0.0:10200",
+        help="Wyoming URI",
+    )
+    parser.add_argument(
+        "--backbone",
+        default="neuphonic/neutts-air",
+        help="Backbone model repository or GGUF path",
+    )
+    parser.add_argument(
+        "--backbone-device",
+        default="cpu",
+        help="Device for the backbone model (e.g. cpu, cuda)",
+    )
+    parser.add_argument(
+        "--codec",
+        default="neuphonic/neucodec",
+        help="Codec repository identifier",
+    )
+    parser.add_argument(
+        "--codec-device",
+        default="cpu",
+        help="Device for the codec (cpu, cuda)",
+    )
+    parser.add_argument(
+        "--voice",
+        action="append",
+        required=True,
+        help=(
+            "Voice definition as comma separated key=value pairs. "
+            "Required keys: name, ref_text, and one of ref_audio/ref_codes. "
+            "Optional keys: description, language."
+        ),
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=2400,
+        help="Number of samples per Wyoming audio chunk",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging output")
+    return parser
+
+
+def main() -> None:
+    parser = _build_argument_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    try:
+        asyncio.run(_run_server(args))
+    except KeyboardInterrupt:
+        LOGGER.info("Shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/neuttsair/constants.py
+++ b/neuttsair/constants.py
@@ -1,0 +1,54 @@
+"""
+Centralized literals and default configuration values for NeuTTSAir.
+"""
+
+DEFAULT_SAMPLE_RATE = 24_000
+DEFAULT_MAX_CONTEXT = 2048
+REFERENCE_ENCODE_SAMPLE_RATE = 16_000
+REFERENCE_MONO = True
+
+CPU_DEVICE = "cpu"
+GPU_DEVICE = "gpu"
+
+DEFAULT_BACKBONE_REPO = "neuphonic/neutts-air"
+DEFAULT_CODEC_REPO = "neuphonic/neucodec"
+DISTILL_CODEC_REPO = "neuphonic/distill-neucodec"
+ONNX_CODEC_REPO = "neuphonic/neucodec-onnx-decoder"
+
+GGUF_SUFFIX = "gguf"
+GGUF_FILENAME_PATTERN = "*.gguf"
+GGUF_GPU_ALL_LAYERS = -1
+GGUF_GPU_NO_LAYERS = 0
+
+PHONEMIZER_LANGUAGE = "en-us"
+PHONEMIZER_PRESERVE_PUNCTUATION = True
+PHONEMIZER_WITH_STRESS = True
+PHONEME_SEPARATOR = " "
+
+TOKEN_SPEECH_REPLACE = "<|SPEECH_REPLACE|>"
+TOKEN_SPEECH_GENERATION_START = "<|SPEECH_GENERATION_START|>"
+TOKEN_SPEECH_GENERATION_END = "<|SPEECH_GENERATION_END|>"
+TOKEN_TEXT_REPLACE = "<|TEXT_REPLACE|>"
+TOKEN_TEXT_PROMPT_START = "<|TEXT_PROMPT_START|>"
+TOKEN_TEXT_PROMPT_END = "<|TEXT_PROMPT_END|>"
+
+SPEECH_TOKEN_FORMAT = "<|speech_{idx}|>"
+SPEECH_TOKEN_REGEX = r"<\|speech_(\d+)\|>"
+
+CHAT_TEMPLATE = "user: Convert the text to speech:{text_token}\nassistant:{speech_token}"
+
+GGML_PROMPT_TEMPLATE = (
+    "user: Convert the text to speech:{text_start}{prompt_body}{text_end}\n"
+    "assistant:{speech_start}{codes}"
+)
+
+GGML_STOP_TOKENS = (TOKEN_SPEECH_GENERATION_END,)
+
+DEFAULT_TEMPERATURE = 1.0
+DEFAULT_TOP_K = 50
+DEFAULT_MIN_NEW_TOKENS = 50
+TORCH_GENERATE_DO_SAMPLE = True
+TORCH_GENERATE_USE_CACHE = True
+
+LLM_OUTPUT_CHOICES_KEY = "choices"
+LLM_OUTPUT_TEXT_KEY = "text"

--- a/neuttsair/neutts.py
+++ b/neuttsair/neutts.py
@@ -8,20 +8,24 @@ from neucodec import NeuCodec, DistillNeuCodec
 from phonemizer.backend import EspeakBackend
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
+from . import constants as const
+
 
 class NeuTTSAir:
 
     def __init__(
         self,
-        backbone_repo="neuphonic/neutts-air",
-        backbone_device="cpu",
-        codec_repo="neuphonic/neucodec",
-        codec_device="cpu",
+        backbone_repo: str = const.DEFAULT_BACKBONE_REPO,
+        backbone_device: str = const.CPU_DEVICE,
+        codec_repo: str = const.DEFAULT_CODEC_REPO,
+        codec_device: str = const.CPU_DEVICE,
+        sample_rate: int = const.DEFAULT_SAMPLE_RATE,
+        max_context: int = const.DEFAULT_MAX_CONTEXT,
     ):
 
         # Consts
-        self.sample_rate = 24_000
-        self.max_context = 2048
+        self.sample_rate = sample_rate
+        self.max_context = max_context
 
         # ggml & onnx flags
         self._grammar = None  # set with a ggml model
@@ -34,7 +38,9 @@ class NeuTTSAir:
         # Load phonemizer + models
         print("Loading phonemizer...")
         self.phonemizer = EspeakBackend(
-            language="en-us", preserve_punctuation=True, with_stress=True
+            language=const.PHONEMIZER_LANGUAGE,
+            preserve_punctuation=const.PHONEMIZER_PRESERVE_PUNCTUATION,
+            with_stress=const.PHONEMIZER_WITH_STRESS,
         )
 
         self._load_backbone(backbone_repo, backbone_device)
@@ -45,10 +51,14 @@ class NeuTTSAir:
         self.watermarker = perth.PerthImplicitWatermarker()
 
     def _load_backbone(self, backbone_repo, backbone_device):
-        print(f"Loading backbone from: {backbone_repo} on {backbone_device} ...")
+        backbone_msg = "Loading backbone from: %s on %s ..." % (
+            backbone_repo,
+            backbone_device,
+        )
+        print(backbone_msg)
 
         # GGUF loading
-        if backbone_repo.endswith("gguf"):
+        if backbone_repo.endswith(const.GGUF_SUFFIX):
 
             try:
                 from llama_cpp import Llama
@@ -61,105 +71,139 @@ class NeuTTSAir:
 
             self.backbone = Llama.from_pretrained(
                 repo_id=backbone_repo,
-                filename="*.gguf",
+                filename=const.GGUF_FILENAME_PATTERN,
                 verbose=False,
-                n_gpu_layers=-1 if backbone_device == "gpu" else 0,
+                n_gpu_layers=(
+                    const.GGUF_GPU_ALL_LAYERS
+                    if backbone_device == const.GPU_DEVICE
+                    else const.GGUF_GPU_NO_LAYERS
+                ),
                 n_ctx=self.max_context,
                 mlock=True,
-                flash_attn=True if backbone_device == "gpu" else False,
+                flash_attn=backbone_device == const.GPU_DEVICE,
             )
             self._is_quantized_model = True
 
         else:
             self.tokenizer = AutoTokenizer.from_pretrained(backbone_repo)
-            self.backbone = AutoModelForCausalLM.from_pretrained(backbone_repo).to(
-                torch.device(backbone_device)
-            )
+            backbone_model = AutoModelForCausalLM.from_pretrained(backbone_repo)
+            device = torch.device(backbone_device)
+            self.backbone = backbone_model.to(device)
 
     def _load_codec(self, codec_repo, codec_device):
 
-        print(f"Loading codec from: {codec_repo} on {codec_device} ...")
+        codec_msg = "Loading codec from: %s on %s ..." % (
+            codec_repo,
+            codec_device,
+        )
+        print(codec_msg)
         match codec_repo:
-            case "neuphonic/neucodec":
+            case const.DEFAULT_CODEC_REPO:
                 self.codec = NeuCodec.from_pretrained(codec_repo)
                 self.codec.eval().to(codec_device)
-            case "neuphonic/distill-neucodec":
+            case const.DISTILL_CODEC_REPO:
                 self.codec = DistillNeuCodec.from_pretrained(codec_repo)
                 self.codec.eval().to(codec_device)
-            case "neuphonic/neucodec-onnx-decoder":
+            case const.ONNX_CODEC_REPO:
 
-                if codec_device != "cpu":
+                if codec_device != const.CPU_DEVICE:
                     raise ValueError("Onnx decoder only currently runs on CPU.")
 
                 try:
                     from neucodec import NeuCodecOnnxDecoder
                 except ImportError as e:
                     raise ImportError(
-                        "Failed to import the onnx decoder."
-                        " Ensure you have onnxruntime installed as well as neucodec >= 0.0.4."
+                        "Failed to import the onnx decoder. Ensure you have "
+                        "onnxruntime installed as well as neucodec >= 0.0.4."
                     ) from e
 
                 self.codec = NeuCodecOnnxDecoder.from_pretrained(codec_repo)
                 self._is_onnx_codec = True
 
             case _:
-                raise ValueError(
-                    "Invalid codec repo! Must be one of:"
-                    " 'neuphonic/neucodec', 'neuphonic/distill-neucodec',"
-                    " 'neuphonic/neucodec-onnx-decoder'."
+                allowed_repos = (
+                    const.DEFAULT_CODEC_REPO,
+                    const.DISTILL_CODEC_REPO,
+                    const.ONNX_CODEC_REPO,
                 )
+                quoted_repos = (f"'{repo}'" for repo in allowed_repos)
+                allowed_list = ", ".join(quoted_repos)
+                message = f"Invalid codec repo! Must be one of: {allowed_list}."
+                raise ValueError(message)
 
-    def infer(self, text: str, ref_codes: np.ndarray | torch.Tensor, ref_text: str) -> np.ndarray:
+    def infer(
+        self,
+        text: str,
+        ref_codes: np.ndarray | torch.Tensor | list[int],
+        ref_text: str,
+    ) -> np.ndarray:
         """
-        Perform inference to generate speech from text using the TTS model and reference audio.
+        Generate speech from text using the TTS model and reference audio.
 
         Args:
             text (str): Input text to be converted to speech.
-            ref_codes (np.ndarray | torch.tensor): Encoded reference.
-            ref_text (str): Reference text for reference audio. Defaults to None.
+            ref_codes (np.ndarray | torch.Tensor): Encoded reference.
+            ref_text (str): Reference transcript for the reference audio.
+
         Returns:
             np.ndarray: Generated speech waveform.
         """
 
+        # Normalize reference codes to plain Python ints
+        ref_codes_list = self._flatten_codes(ref_codes)
+
         # Generate tokens
         if self._is_quantized_model:
-            output_str = self._infer_ggml(ref_codes, ref_text, text)
+            output_str = self._infer_ggml(ref_codes_list, ref_text, text)
         else:
-            prompt_ids = self._apply_chat_template(ref_codes, ref_text, text)
+            prompt_ids = self._apply_chat_template(
+                ref_codes_list,
+                ref_text,
+                text,
+            )
             output_str = self._infer_torch(prompt_ids)
 
         # Decode
         wav = self._decode(output_str)
-        watermarked_wav = self.watermarker.apply_watermark(wav, sample_rate=24_000)
+        watermarked_wav = self.watermarker.apply_watermark(
+            wav,
+            sample_rate=self.sample_rate,
+        )
 
         return watermarked_wav
 
     def encode_reference(self, ref_audio_path: str | Path):
-        wav, _ = librosa.load(ref_audio_path, sr=16000, mono=True)
+        wav, _ = librosa.load(
+            ref_audio_path,
+            sr=const.REFERENCE_ENCODE_SAMPLE_RATE,
+            mono=const.REFERENCE_MONO,
+        )
         wav_tensor = torch.from_numpy(wav).float().unsqueeze(0).unsqueeze(0)  # [1, 1, T]
         with torch.no_grad():
-            ref_codes = self.codec.encode_code(audio_or_path=wav_tensor).squeeze(0).squeeze(0)
-        return ref_codes
+            encoded_codes = self.codec.encode_code(audio_or_path=wav_tensor)
+            ref_codes = encoded_codes.squeeze(0).squeeze(0)
+        return self._flatten_codes(ref_codes)
 
     def _decode(self, codes: str):
 
         # Extract speech token IDs using regex
-        speech_ids = [int(num) for num in re.findall(r"<\|speech_(\d+)\|>", codes)]
+        matches = re.findall(const.SPEECH_TOKEN_REGEX, codes)
+        speech_ids = [int(num) for num in matches]
 
         if len(speech_ids) > 0:
 
             # Onnx decode
             if self._is_onnx_codec:
-                codes = np.array(speech_ids, dtype=np.int32)[np.newaxis, np.newaxis, :]
-                recon = self.codec.decode_code(codes)
+                speech_array = np.array(speech_ids, dtype=np.int32)
+                speech_array = speech_array[np.newaxis, np.newaxis, :]
+                recon = self.codec.decode_code(speech_array)
 
             # Torch decode
             else:
                 with torch.no_grad():
-                    codes = torch.tensor(speech_ids, dtype=torch.long)[None, None, :].to(
-                        self.codec.device
-                    )
-                    recon = self.codec.decode_code(codes).cpu().numpy()
+                    speech_tensor = torch.tensor(speech_ids, dtype=torch.long)
+                    speech_tensor = speech_tensor[None, None, :].to(self.codec.device)
+                    recon = self.codec.decode_code(speech_tensor).cpu().numpy()
 
             return recon[0, 0, :]
         else:
@@ -168,23 +212,28 @@ class NeuTTSAir:
     def _to_phones(self, text: str) -> str:
         phones = self.phonemizer.phonemize([text])
         phones = phones[0].split()
-        phones = " ".join(phones)
+        phones = const.PHONEME_SEPARATOR.join(phones)
         return phones
 
     def _apply_chat_template(
         self, ref_codes: list[int], ref_text: str, input_text: str
     ) -> list[int]:
 
-        input_text = self._to_phones(ref_text) + " " + self._to_phones(input_text)
-        speech_replace = self.tokenizer.convert_tokens_to_ids("<|SPEECH_REPLACE|>")
-        speech_gen_start = self.tokenizer.convert_tokens_to_ids("<|SPEECH_GENERATION_START|>")
-        text_replace = self.tokenizer.convert_tokens_to_ids("<|TEXT_REPLACE|>")
-        text_prompt_start = self.tokenizer.convert_tokens_to_ids("<|TEXT_PROMPT_START|>")
-        text_prompt_end = self.tokenizer.convert_tokens_to_ids("<|TEXT_PROMPT_END|>")
+        input_text = (
+            self._to_phones(ref_text) + const.PHONEME_SEPARATOR + self._to_phones(input_text)
+        )
+        speech_replace = self.tokenizer.convert_tokens_to_ids(const.TOKEN_SPEECH_REPLACE)
+        speech_gen_start = self.tokenizer.convert_tokens_to_ids(const.TOKEN_SPEECH_GENERATION_START)
+        text_replace = self.tokenizer.convert_tokens_to_ids(const.TOKEN_TEXT_REPLACE)
+        text_prompt_start = self.tokenizer.convert_tokens_to_ids(const.TOKEN_TEXT_PROMPT_START)
+        text_prompt_end = self.tokenizer.convert_tokens_to_ids(const.TOKEN_TEXT_PROMPT_END)
 
         input_ids = self.tokenizer.encode(input_text, add_special_tokens=False)
-        chat = """user: Convert the text to speech:<|TEXT_REPLACE|>\nassistant:<|SPEECH_REPLACE|>"""
-        ids = self.tokenizer.encode(chat)
+        chat_prompt = const.CHAT_TEMPLATE.format(
+            text_token=const.TOKEN_TEXT_REPLACE,
+            speech_token=const.TOKEN_SPEECH_REPLACE,
+        )
+        ids = self.tokenizer.encode(chat_prompt)
 
         text_replace_idx = ids.index(text_replace)
         ids = (
@@ -196,7 +245,7 @@ class NeuTTSAir:
         )
 
         speech_replace_idx = ids.index(speech_replace)
-        codes_str = "".join([f"<|speech_{i}|>" for i in ref_codes])
+        codes_str = "".join([const.SPEECH_TOKEN_FORMAT.format(idx=i) for i in ref_codes])
         codes = self.tokenizer.encode(codes_str, add_special_tokens=False)
         ids = ids[:speech_replace_idx] + [speech_gen_start] + list(codes)
 
@@ -204,21 +253,22 @@ class NeuTTSAir:
 
     def _infer_torch(self, prompt_ids: list[int]) -> str:
         prompt_tensor = torch.tensor(prompt_ids).unsqueeze(0).to(self.backbone.device)
-        speech_end_id = self.tokenizer.convert_tokens_to_ids("<|SPEECH_GENERATION_END|>")
+        speech_end_id = self.tokenizer.convert_tokens_to_ids(const.TOKEN_SPEECH_GENERATION_END)
         with torch.no_grad():
             output_tokens = self.backbone.generate(
                 prompt_tensor,
                 max_length=self.max_context,
                 eos_token_id=speech_end_id,
-                do_sample=True,
-                temperature=1.0,
-                top_k=50,
-                use_cache=True,
-                min_new_tokens=50,
+                do_sample=const.TORCH_GENERATE_DO_SAMPLE,
+                temperature=const.DEFAULT_TEMPERATURE,
+                top_k=const.DEFAULT_TOP_K,
+                use_cache=const.TORCH_GENERATE_USE_CACHE,
+                min_new_tokens=const.DEFAULT_MIN_NEW_TOKENS,
             )
         input_length = prompt_tensor.shape[-1]
         output_str = self.tokenizer.decode(
-            output_tokens[0, input_length:].cpu().numpy().tolist(), add_special_tokens=False
+            output_tokens[0, input_length:].cpu().numpy().tolist(),
+            add_special_tokens=False,
         )
         return output_str
 
@@ -226,17 +276,40 @@ class NeuTTSAir:
         ref_text = self._to_phones(ref_text)
         input_text = self._to_phones(input_text)
 
-        codes_str = "".join([f"<|speech_{idx}|>" for idx in ref_codes])
-        prompt = (
-            f"user: Convert the text to speech:<|TEXT_PROMPT_START|>{ref_text} {input_text}"
-            f"<|TEXT_PROMPT_END|>\nassistant:<|SPEECH_GENERATION_START|>{codes_str}"
+        prompt_body = const.PHONEME_SEPARATOR.join([ref_text, input_text])
+        codes_str = "".join(const.SPEECH_TOKEN_FORMAT.format(idx=idx) for idx in ref_codes)
+        prompt = const.GGML_PROMPT_TEMPLATE.format(
+            text_start=const.TOKEN_TEXT_PROMPT_START,
+            prompt_body=prompt_body,
+            text_end=const.TOKEN_TEXT_PROMPT_END,
+            speech_start=const.TOKEN_SPEECH_GENERATION_START,
+            codes=codes_str,
         )
         output = self.backbone(
             prompt,
             max_tokens=self.max_context,
-            temperature=1.0,
-            top_k=50,
-            stop=["<|SPEECH_GENERATION_END|>"],
+            temperature=const.DEFAULT_TEMPERATURE,
+            top_k=const.DEFAULT_TOP_K,
+            stop=list(const.GGML_STOP_TOKENS),
         )
-        output_str = output["choices"][0]["text"]
+        choices = output[const.LLM_OUTPUT_CHOICES_KEY]
+        output_str = choices[0][const.LLM_OUTPUT_TEXT_KEY]
         return output_str
+
+    def _flatten_codes(
+        self, codes: np.ndarray | torch.Tensor | list[int] | tuple[int, ...]
+    ) -> list[int]:
+        """
+        Convert reference codes into a flat list of Python ints to avoid tensor
+        wrappers when building prompts.
+        """
+        if isinstance(codes, torch.Tensor):
+            codes = codes.detach().cpu().view(-1).tolist()
+        elif isinstance(codes, np.ndarray):
+            codes = codes.reshape(-1).tolist()
+        elif isinstance(codes, (list, tuple)):
+            codes = list(codes)
+        else:
+            codes = [codes]
+
+        return [int(code) for code in codes]


### PR DESCRIPTION
This refactor centralizes the configuration constants into a shared module to improve maintainability and reduce duplication across the project. By moving the constants into a single, dedicated module, it becomes easier to manage and update values in one place. This change enhances code clarity and consistency by eliminating scattered configuration values.

### Changes:
- Created a new module (`constants.py`) for storing shared configuration constants.
- Moved the configuration constants from various files to the `constants.py` module.
- Updated relevant files to import constants from the new shared module.
- Removed redundant definitions of constants in the project.

### Benefits:
- Centralized management of configuration constants.
- Improved code maintainability by reducing duplication.
- Easier updates to configuration values across the project.

Please review and merge when ready.
