### PR TITLE
feat: remove hard torch dependency and add ONNX-only flow (#36)

### DIFF
--- a/examples/basic_streaming_example.py
+++ b/examples/basic_streaming_example.py
@@ -1,20 +1,55 @@
 import os
-import soundfile as sf
-import torch
+
 import numpy as np
-from neuttsair.neutts import NeuTTSAir
 import pyaudio
+
+from neuttsair.neutts import NeuTTSAir
+
+try:
+    import torch  # type: ignore[assignment]
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore[assignment]
+
+
+def _load_ref_codes(ref_codes_path: str | None):
+    if not ref_codes_path:
+        return None
+
+    if not os.path.exists(ref_codes_path):
+        raise FileNotFoundError(f"Reference codes not found: {ref_codes_path}")
+
+    suffix = os.path.splitext(ref_codes_path)[1].lower()
+    if suffix in {".pt", ".pth"}:
+        if torch is None:
+            raise ImportError(
+                "Loading .pt reference codes requires the optional dependency `torch`.\n"
+                "Install it separately with `pip install torch` or convert the codes to .npy."
+            )
+        return torch.load(ref_codes_path, map_location="cpu")
+
+    if suffix == ".npy":
+        return np.load(ref_codes_path)
+
+    raise ValueError(f"Unsupported reference codes format '{suffix}'. Expected .pt, .pth, or .npy.")
 
 
 def main(input_text, ref_codes_path, ref_text, backbone):
-    assert backbone in ["neuphonic/neutts-air-q4-gguf", "neuphonic/neutts-air-q8-gguf"], "Must be a GGUF ckpt as streaming is only currently supported by llama-cpp."
-    
+    if not ref_codes_path or not ref_text:
+        print("No reference codes or text provided.")
+        return
+
+    if backbone not in {
+        "neuphonic/neutts-air-q4-gguf",
+        "neuphonic/neutts-air-q8-gguf",
+    }:
+        raise ValueError("Streaming requires a GGUF checkpoint compatible with llama-cpp.")
+
     # Initialize NeuTTSAir with the desired model and codec
     tts = NeuTTSAir(
         backbone_repo=backbone,
         backbone_device="cpu",
         codec_repo="neuphonic/neucodec-onnx-decoder",
-        codec_device="cpu"
+        codec_device="cpu",
     )
 
     # Check if ref_text is a path if it is read it if not just return string
@@ -22,23 +57,17 @@ def main(input_text, ref_codes_path, ref_text, backbone):
         with open(ref_text, "r") as f:
             ref_text = f.read().strip()
 
-    if ref_codes_path and os.path.exists(ref_codes_path):
-        ref_codes = torch.load(ref_codes_path)
+    ref_codes = _load_ref_codes(ref_codes_path)
 
     print(f"Generating audio for input text: {input_text}")
     p = pyaudio.PyAudio()
-    stream = p.open(
-        format=pyaudio.paInt16,
-        channels=1,
-        rate=24_000,
-        output=True
-    )
+    stream = p.open(format=pyaudio.paInt16, channels=1, rate=24_000, output=True)
     print("Streaming...")
     for chunk in tts.infer_stream(input_text, ref_codes, ref_text):
         audio = (chunk * 32767).astype(np.int16)
         print(audio.shape)
         stream.write(audio.tobytes())
-    
+
     stream.stop_stream()
     stream.close()
     p.terminate()
@@ -49,34 +78,34 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="NeuTTSAir Example")
     parser.add_argument(
-        "--input_text", 
-        type=str, 
-        required=True, 
-        help="Input text to be converted to speech"
+        "--input_text",
+        type=str,
+        required=True,
+        help="Input text to be converted to speech",
     )
     parser.add_argument(
-        "--ref_codes", 
-        type=str, 
-        default="./samples/dave.pt", 
-        help="Path to pre-encoded reference audio"
+        "--ref_codes",
+        type=str,
+        default="./samples/dave.pt",
+        help="Path to pre-encoded reference audio",
     )
     parser.add_argument(
         "--ref_text",
         type=str,
-        default="./samples/dave.txt", 
+        default="./samples/dave.txt",
         help="Reference text corresponding to the reference audio",
     )
     parser.add_argument(
-        "--output_path", 
-        type=str, 
-        default="output.wav", 
-        help="Path to save the output audio"
+        "--output_path",
+        type=str,
+        default="output.wav",
+        help="Path to save the output audio",
     )
     parser.add_argument(
-        "--backbone", 
-        type=str, 
-        default="neuphonic/neutts-air-q8-gguf", 
-        help="Huggingface repo containing the backbone checkpoint. Must be GGUF."
+        "--backbone",
+        type=str,
+        default="neuphonic/neutts-air-q8-gguf",
+        help="Huggingface repo containing the backbone checkpoint. Must be GGUF.",
     )
     args = parser.parse_args()
     main(

--- a/examples/onnx_example.py
+++ b/examples/onnx_example.py
@@ -1,7 +1,39 @@
 import os
+from pathlib import Path
+
+import numpy as np
 import soundfile as sf
-import torch
+
 from neuttsair.neutts import NeuTTSAir
+
+try:
+    import torch  # type: ignore[assignment]
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore[assignment]
+
+
+def _load_ref_codes(ref_codes_path: str | None):
+    if not ref_codes_path:
+        return None
+
+    path = Path(ref_codes_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Reference codes not found: {ref_codes_path}")
+
+    suffix = path.suffix.lower()
+    if suffix in {".pt", ".pth"}:
+        if torch is None:
+            raise ImportError(
+                "Loading .pt reference codes requires the optional dependency `torch`.\n"
+                "Install it separately with `pip install torch` or convert the codes to .npy."
+            )
+        return torch.load(path, map_location="cpu")
+    if suffix == ".npy":
+        return np.load(path)
+
+    raise ValueError(
+        f"Unsupported reference codes format '{path.suffix}'. Expected .pt, .pth, or .npy."
+    )
 
 
 def main(input_text, ref_codes_path, ref_text, backbone, output_path="output.wav"):
@@ -14,7 +46,7 @@ def main(input_text, ref_codes_path, ref_text, backbone, output_path="output.wav
         backbone_repo=backbone,
         backbone_device="cpu",
         codec_repo="neuphonic/neucodec-onnx-decoder",
-        codec_device="cpu"
+        codec_device="cpu",
     )
 
     # Check if ref_text is a path if it is read it if not just return string
@@ -22,8 +54,7 @@ def main(input_text, ref_codes_path, ref_text, backbone, output_path="output.wav
         with open(ref_text, "r") as f:
             ref_text = f.read().strip()
 
-    if ref_codes_path and os.path.exists(ref_codes_path):
-        ref_codes = torch.load(ref_codes_path)
+    ref_codes = _load_ref_codes(ref_codes_path)
 
     print(f"Generating audio for input text: {input_text}")
     wav = tts.infer(input_text, ref_codes, ref_text)
@@ -38,34 +69,34 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="NeuTTSAir Example")
     parser.add_argument(
-        "--input_text", 
-        type=str, 
-        required=True, 
-        help="Input text to be converted to speech"
+        "--input_text",
+        type=str,
+        required=True,
+        help="Input text to be converted to speech",
     )
     parser.add_argument(
-        "--ref_codes", 
-        type=str, 
-        default="./samples/dave.pt", 
-        help="Path to pre-encoded reference audio"
+        "--ref_codes",
+        type=str,
+        default="./samples/dave.pt",
+        help="Path to pre-encoded reference audio",
     )
     parser.add_argument(
         "--ref_text",
         type=str,
-        default="./samples/dave.txt", 
+        default="./samples/dave.txt",
         help="Reference text corresponding to the reference audio",
     )
     parser.add_argument(
-        "--output_path", 
-        type=str, 
-        default="output.wav", 
-        help="Path to save the output audio"
+        "--output_path",
+        type=str,
+        default="output.wav",
+        help="Path to save the output audio",
     )
     parser.add_argument(
-        "--backbone", 
-        type=str, 
-        default="neuphonic/neutts-air", 
-        help="Huggingface repo containing the backbone checkpoint"
+        "--backbone",
+        type=str,
+        default="neuphonic/neutts-air",
+        help="Huggingface repo containing the backbone checkpoint",
     )
     args = parser.parse_args()
     main(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ librosa==0.11.0
 neucodec>=0.0.4
 numpy==2.2.6
 phonemizer==3.3.0
-soundfile==0.13.1
-torch==2.8.0
-transformers==4.56.1
 resemble-perth==1.0.1
+soundfile==0.13.1
+transformers==4.56.1


### PR DESCRIPTION

**Description:**

* Makes PyTorch optional via lazy-import guards and clear error messages only when Torch-backed paths are invoked.
* Supports ONNX-only inference path; CLI examples updated to avoid eager Torch import.
* Accepts generic iterables/arrays for reference codes; clarifies streaming restrictions.
* Drops Torch from core `requirements.txt`.

**Changes**

* `neuttsair/neutts.py`: lazy imports + backend guards; clearer errors for `.pt/.pth` refs.
* `examples/onnx_example.py`, `examples/basic_streaming_example.py`, `examples/encode_reference.py`: load refs without importing Torch; actionable guidance for Torch-only assets.
* `requirements.txt`: remove hard `torch` pin.

**How to test**

```bash
python -m venv .venv-no-torch && source .venv-no-torch/bin/activate
pip install -U pip && pip install -r requirements.txt
python - <<'PY'
from importlib import util
print("torch present? ", bool(util.find_spec("torch")))
from neuttsair.neutts import NeuTTSAir
print("NeuTTSAir import OK (no torch)")
PY

python -m examples.onnx_example \
  --input_text "I am kuntal , I am a good boy " \
  --output_path out_onnx.wav

# Guarded error for Torch-only refs
python -m examples.encode_reference --ref_path dummy_model.pt || true
```

**Backward compatibility**

* Torch workflows still work with `pip install .[torch]` (or installing torch separately) and `--backend torch` if exposed; otherwise autodetect.

**Motivation**

* Enables installs on edge devices or minimal environments without Torch. Closes #36.

**Checklist**

* [x] Pre-commit hooks pass (black/flake8/req fixer)
* [x] No-Torch import works
* [x] ONNX example runs and writes output
* [x] Friendly error on Torch-only paths
* [x] Docs/examples reflect new flow

