### PR TITLE
Fix typo in examples README for llama-cpp-python

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,7 @@ python -m examples.onnx_example \
 
 ### Streaming Support 
 
-To stream the model output in chunks, try out the `onnx_streaming.py` example. For streaming, only the GGUF backends are currently supported. Ensure you have `llama-cpp-pyhon`, `onnxruntime` and `pyaudio` installed to run this example.
+To stream the model output in chunks, try out the `onnx_streaming.py` example. For streaming, only the GGUF backends are currently supported. Ensure you have `llama-cpp-python`, `onnxruntime` and `pyaudio` installed to run this example.
 
 ```bash
 python -m examples.basic_streaming_example \


### PR DESCRIPTION
Corrected the spelling of 'llama-cpp-pyhon' to 'llama-cpp-python' in the examples README.