### PR TITLE
fix: offloading model layers to gpu and using flash_attn for gpu

### DIFF
--- a/neuttsair/neutts.py
+++ b/neuttsair/neutts.py
@@ -97,10 +97,10 @@ class NeuTTSAir:
                 repo_id=backbone_repo,
                 filename="*.gguf",
                 verbose=False,
-                n_gpu_layers=-1 if backbone_device == "gpu" else 0,
+                n_gpu_layers=-1 if backbone_device.startswith(("cuda", "gpu")) else 0,
                 n_ctx=self.max_context,
                 mlock=True,
-                flash_attn=True if backbone_device == "gpu" else False,
+                flash_attn=True if backbone_device.startswith(("cuda", "gpu")) else False,
             )
             self._is_quantized_model = True
 


### PR DESCRIPTION
### Context:
The `_load_backbone` functions loads the neutts-air backbone for inference. While this function works as intended for CPU inference, GPU inference is slowed down due to faults in code

### Problem:
Considering that `backbone_device` is used to export the model to the appropriate device, "gpu" isn't a valid string for `.to()` hence users resort to the standard "cuda" or strings having "cuda" such as "cuda:0" as a prefix. The current if conditions

`n_gpu_layers=-1 if backbone_device == "gpu" else 0`
and
`flash_attn=True if backbone_device == "gpu" else False`
do not have the intended effect of offloading the model to GPU and using flash-attention since the string is checked for "gpu"

### Fix:
- check string for "cuda" and "gpu" using python's inbuilt `startswith` method for strings ensures usage of "cuda" as `backbone_device` leads to intended behaviour 
- checking for "gpu" alongside "cuda" ensures the change is not code-breaking for existing users

### TODOs:
- include other device strings that may be utilized for GPU inference and support usage of `flash_attn` and use of `n_gpu_layers` with gguf