### PR TITLE
Add support for inference with vLLM or other OpenAI-compatible server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ NeuTTS Air is built off Qwen 0.5B - a lightweight yet capable language model opt
 - **Responsibility**: Watermarked outputs
 - **Inference Speed**: Real-time generation on mid-range devices
 - **Power Consumption**: Optimised for mobile and embedded devices
+- **Compatibility**: Supports streaming inference with [llama.cpp](https://github.com/ggml-org/llama.cpp), [vLLM](https://docs.vllm.ai/en/stable/), or any other OpenAI-compatible server
 
 ## Get Started
 
@@ -159,6 +160,8 @@ python -m examples.basic_streaming_example \
 ```
 
 Again, a particular model repo can be specified with the `--backbone` argument - note that for streaming the model must be in GGUF format.
+
+Alternatively, streaming can be done with any backbone served over an OpenAI-compatible server using the `vllm_streaming_example.py` script. See the [examples README](examples/README.md#streaming-support) for more details.
 
 ## Preparing References for Cloning
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,10 @@ python -m examples.onnx_example \
 
 ### Streaming Support 
 
-To stream the model output in chunks, try out the `onnx_streaming.py` example. For streaming, only the GGUF backends are currently supported. Ensure you have `llama-cpp-python`, `onnxruntime` and `pyaudio` installed to run this example.
+To stream the model output in chunks, try out the `basic_streaming_example.py` for streaming with GGUF backends or `vllm_streaming_example.py` for streaming with any backend exposed over an OpenAI-compatible server.
+
+#### GGUF Streaming Example
+Ensure you have `llama-cpp-python`, `onnxruntime` and `pyaudio` installed to run this example.
 
 ```bash
 python -m examples.basic_streaming_example \
@@ -47,4 +50,24 @@ python -m examples.basic_streaming_example \
   --ref_codes samples/dave.pt \
   --ref_text samples/dave.txt \
   --backbone neuphonic/neutts-air-q4-gguf
+```
+
+#### vLLM Streaming Example
+Ensure you have `vllm`, `openai`, `onnxruntime` and `pyaudio` installed to run this example.
+See [vLLM docs](https://docs.vllm.ai/en/stable/) for instructions on setting up a vLLM server.
+
+First run vLLM to serve the desired backbone model:
+```bash
+vllm serve neuphonic/neutts-air
+```
+
+Then run the streaming example script:
+```bash
+python -m examples.vllm_streaming_example \
+  --input_text "My name is Dave, and um, I'm from London" \
+  --ref_codes samples/dave.pt \
+  --ref_text samples/dave.txt \
+  --backbone neuphonic/neutts-air \
+  --vllm_url http://localhost:8000/v1 \
+  --vllm_api_key empty
 ```

--- a/examples/vllm_streaming_example.py
+++ b/examples/vllm_streaming_example.py
@@ -1,0 +1,99 @@
+import os
+import soundfile as sf
+import torch
+import numpy as np
+from neuttsair.neutts import NeuTTSAir
+import pyaudio
+
+
+def main(input_text, ref_codes_path, ref_text, backbone, vllm_url, vllm_api_key):
+    # Initialize NeuTTSAir with the desired model and codec
+    tts = NeuTTSAir(
+        backbone_repo=backbone,
+        backbone_device=f"{vllm_url}|{vllm_api_key}",
+        codec_repo="neuphonic/neucodec-onnx-decoder",
+        codec_device="cpu"
+    )
+
+    # Check if ref_text is a path if it is read it if not just return string
+    if ref_text and os.path.exists(ref_text):
+        with open(ref_text, "r") as f:
+            ref_text = f.read().strip()
+
+    if ref_codes_path and os.path.exists(ref_codes_path):
+        ref_codes = torch.load(ref_codes_path)
+
+    print(f"Generating audio for input text: {input_text}")
+    p = pyaudio.PyAudio()
+    stream = p.open(
+        format=pyaudio.paInt16,
+        channels=1,
+        rate=24_000,
+        output=True
+    )
+    print("Streaming...")
+    for chunk in tts.infer_stream(input_text, ref_codes, ref_text):
+        audio = (chunk * 32767).astype(np.int16)
+        print(audio.shape)
+        stream.write(audio.tobytes())
+    
+    stream.stop_stream()
+    stream.close()
+    p.terminate()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="NeuTTSAir Example")
+    parser.add_argument(
+        "--input_text", 
+        type=str, 
+        required=True, 
+        help="Input text to be converted to speech"
+    )
+    parser.add_argument(
+        "--ref_codes", 
+        type=str, 
+        default="./samples/dave.pt", 
+        help="Path to pre-encoded reference audio"
+    )
+    parser.add_argument(
+        "--ref_text",
+        type=str,
+        default="./samples/dave.txt", 
+        help="Reference text corresponding to the reference audio",
+    )
+    parser.add_argument(
+        "--output_path", 
+        type=str, 
+        default="output.wav", 
+        help="Path to save the output audio"
+    )
+    parser.add_argument(
+        "--backbone", 
+        type=str, 
+        default="neuphonic/neutts-air", 
+        help="Huggingface repo containing the backbone checkpoint."
+    )
+    parser.add_argument(
+        "--vllm_url",
+        type=str,
+        default="http://localhost:8000/v1",
+        help="URL of the vLLM server."
+    )
+    parser.add_argument(
+        "--vllm_api_key",
+        type=str,
+        default="empty",
+        help="API key for the vLLM server."
+    )
+    args = parser.parse_args()
+    main(
+        input_text=args.input_text,
+        ref_codes_path=args.ref_codes,
+        ref_text=args.ref_text,
+        backbone=args.backbone,
+        vllm_url=args.vllm_url,
+        vllm_api_key=args.vllm_api_key,
+    )


### PR DESCRIPTION
Addresses #76 by adding support for inference where the backend is an OpenAI client. This allows vLLM or any other OpenAI-compatible server to be used, since `neuphonic/neutts-air` is a standard `Qwen2ForCausalLM` backbone supported by most inference engines today out of the box.

First run vLLM to serve the desired backbone model:
```bash
vllm serve neuphonic/neutts-air
```

Then run the streaming example script:
```bash
python -m examples.vllm_streaming_example \
  --input_text "My name is Dave, and um, I'm from London" \
  --ref_codes samples/dave.pt \
  --ref_text samples/dave.txt \
  --backbone neuphonic/neutts-air \
  --vllm_url http://localhost:8000/v1 \
  --vllm_api_key empty
```