### PR TITLE
Add Apple Metal support and optimize token pipeline with Gradio UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # NeuTTS
 
-HuggingFace 🤗:
+HuggingFace:
 
 - NeuTTS-Air (English): [Model](https://huggingface.co/neuphonic/neutts-air), [Q8 GGUF](https://huggingface.co/neuphonic/neutts-air-q8-gguf), [Q4 GGUF](https://huggingface.co/neuphonic/neutts-air-q4-gguf), [Space](https://huggingface.co/spaces/neuphonic/neutts-air)
 
 - NeuTTS-Nano Multilingual Collection:
    - NeuTTS-Nano (English): [Model](https://huggingface.co/neuphonic/neutts-nano), [Q8 GGUF](https://huggingface.co/neuphonic/neutts-nano-q8-gguf), [Q4 GGUF](https://huggingface.co/neuphonic/neutts-nano-q4-gguf)
    - NeuTTS-Nano-French: [Model](https://huggingface.co/neuphonic/neutts-nano-french), [Q8 GGUF](https://huggingface.co/neuphonic/neutts-nano-french-q8-gguf), [Q4 GGUF](https://huggingface.co/neuphonic/neutts-nano-french-q4-gguf)
-   - NeuTTS-Nano-German: [Model](https://huggingface.co/neuphonic/neutts-nano-german), [Q8 GGUF](https://huggingface.co/neuphonic/neutts-nano-german-q8-gguf), [Q4 GGUF](https://huggingface.co/neuphonic/neutts-nano-german-q4-gguf)
+   - NeuTTS-Nano-German: [Model](https://huggingface.co/neuphonic/neutts-nano-german), [Q8 GGUF](https://huggingface.co/neuphonic/neutts-nano-german-q8-gguf), [Q4 GGUF](https://huggingface.co/neuphonic/neutts-nano-german-q8-gguf)
    - NeuTTS-Nano-Spanish: [Model](https://huggingface.co/neuphonic/neutts-nano-spanish), [Q8 GGUF](https://huggingface.co/neuphonic/neutts-nano-spanish-q8-gguf), [Q4 GGUF](https://huggingface.co/neuphonic/neutts-nano-spanish-q4-gguf)
    - [Multilingual Space](https://huggingface.co/spaces/neuphonic/neutts-nano-multilingual-collection)
 
@@ -15,32 +15,33 @@ HuggingFace 🤗:
 
 _Created by [Neuphonic](http://neuphonic.com/) - building faster, smaller, on-device voice AI_
 
-State-of-the-art Voice AI has been locked behind web APIs for too long. NeuTTS is a collection of open source, on-device, TTS speech language models with instant voice cloning. Built off of LLM backbones, NeuTTS brings natural-sounding speech, real-time performance, built-in security and speaker cloning to your local device - unlocking a new category of embedded voice agents, assistants, toys, and compliance-safe apps.
+State-of-the-art Voice AI has been locked behind web APIs for too long. NeuTTS is a collection of open source, on-device TTS speech language models with instant voice cloning. Built off of LLM backbones, NeuTTS brings natural-sounding speech, real-time performance, built-in security and speaker cloning to your local device—unlocking a new category of embedded voice agents, assistants, toys, and compliance-safe apps.
 
 ## Key Features
 
-- 🗣Best-in-class realism for their size - produce natural, ultra-realistic voices that sound human, at the sweet spot between speed, size, and quality for real-world applications
-- 📱Optimised for on-device deployment - quantisations provided in GGUF format, ready to run on phones, laptops, or even Raspberry Pis
-- 👫Instant voice cloning - create your own speaker with as little as 3 seconds of audio
-- 🚄Simple LM + codec architecture - making development and deployment simple
+- **Best-in-class realism** — Natural, ultra-realistic voices at the sweet spot between speed, size, and quality
+- **Optimised for on-device** — Quantisations in GGUF format, ready to run on phones, laptops, Raspberry Pis, and Apple Silicon Macs with GPU acceleration
+- **Instant voice cloning** — Create your own speaker with as little as 3 seconds of audio
+- **Simple LM + codec** — Straightforward architecture makes development and deployment simple
+- **Apple Silicon GPU support** — Metal-accelerated inference on M-series Macs (M1–M4) with native one-command `run.sh` launcher
+- **Tunable generation** — Expose sampling parameters (temperature, top-k) to control output diversity and quality
+- **Performance optimized** — Cached token lookups, compiled regex, optimized streaming pipeline with reduced watermark overhead
 
 > [!CAUTION]
-> Websites like neutts.com are popping up and they're not affliated with Neuphonic, our github or this repo.
->
-> We are on neuphonic.com only. Please be careful out there! 🙏
+> Websites like neutts.com are popping up and they're not affiliated with Neuphonic, our github or this repo.
+> We are on neuphonic.com only. Please be careful out there!
 
 ## Model Details
 
-NeuTTS models are built from small LLM backbones - lightweight yet capable language models optimised for text understanding and generation - as well as a powerful combination of technologies designed for efficiency and quality:
+NeuTTS models are built from small LLM backbones—lightweight yet capable language models optimised for text understanding and generation—combined with powerful technologies designed for efficiency and quality:
 
 - **Supported Languages**: English, Spanish, German, French (model-dependent)
-- **Audio Codec**: [NeuCodec](https://huggingface.co/neuphonic/neucodec) - our 50hz neural audio codec that achieves exceptional audio quality at low bitrates using a single codebook
+- **Audio Codec**: [NeuCodec](https://huggingface.co/neuphonic/neucodec) — 50Hz neural audio codec with exceptional quality at low bitrates using a single codebook
 - **Context Window**: 2048 tokens, enough for processing ~30 seconds of audio (including prompt duration)
 - **Format**: Quantisations available in GGUF format for efficient on-device inference
-- **Responsibility**: Watermarked outputs
-- **Inference Speed**: Real-time generation on mid-range devices
+- **Responsibility**: Watermarked outputs for authenticity verification
+- **Inference Speed**: Real-time generation on mid-range devices; GPU acceleration available
 - **Power Consumption**: Optimised for mobile and embedded devices
-
 
 |  | NeuTTS-Air | NeuTTS-Nano Models |
 |---|---:|---:|
@@ -51,119 +52,144 @@ NeuTTS models are built from small LLM backbones - lightweight yet capable langu
 
 ## Throughput Benchmarking
 
-These benchmarks are for the Q4_0 quantisations [neutts-air-Q4_0](https://huggingface.co/neuphonic/neutts-air-q4-gguf) and [neutts-nano-Q4_0](https://huggingface.co/neuphonic/neutts-nano-q4-gguf). Note that all models in the NeuTTS-Nano Multilingual Collection have an identical architecture, so these results should apply for any Q4_0 model in the collection.
+Benchmarks for Q4_0 quantisations: [neutts-air-Q4_0](https://huggingface.co/neuphonic/neutts-air-q4-gguf) and [neutts-nano-Q4_0](https://huggingface.co/neuphonic/neutts-nano-q4-gguf). All models in the NeuTTS-Nano Multilingual Collection have identical architecture, so results apply across languages.
 
-CPU benchmarking used [llama-bench](https://github.com/ggml-org/llama.cpp/tree/master/tools/llama-bench) (from llama.cpp) to measure prefill and decode throughput at multiple context sizes. For the GPU benchmark (RTX 4090), we leverage vLLM to maximise throughput, using the [vLLM benchmark](https://docs.vllm.ai/en/stable/cli/bench/throughput/).
+CPU benchmarking used [llama-bench](https://github.com/ggml-org/llama.cpp/tree/master/tools/llama-bench) to measure prefill and decode throughput. GPU benchmarking (RTX 4090) uses vLLM to maximise throughput.
 
-We include benchmarks on four devices: Galaxy A25 5G, AMD Ryzen 9HX 370, iMac M4 16GB, NVIDIA GeForce RTX 4090.
-
+**Devices tested**: Galaxy A25 5G (CPU), AMD Ryzen 9 HX 370 (CPU), iMac M4 16GB (CPU + GPU estimates), Apple M2 16GB (CPU + GPU estimated), NVIDIA RTX 4090 (GPU)
 
 |  | NeuTTS-Air | NeuTTS-Nano |
 |---|---:|---:|
-| **Galaxy A25 5G (CPU only)** | 20 tokens/s | 45 tokens/s|
-| **AMD Ryzen 9 HX 370 (CPU only)** | 119 tokens/s | 221 tokens/s |
-| **iMAc M4 16 GB (CPU only)** | 111 tokens/s | 195 tokens/s |
-| **RTX 4090** | 16194 tokens/s | 19268 tokens/s |
-
-
-> [!NOTE]
->  llama-bench used 14 threads for prefill and 16 threads for decode (as configured in the benchmark run) on AMD Ryzen 9HX 370 and iMac M4 16GB, and 6 threads for each on the Galaxy A25 5G. The tokens/s reported are when having 500 prefill tokens and generating 250 output tokens.
+| **Galaxy A25 5G (CPU)** | 20 tokens/s | 45 tokens/s |
+| **AMD Ryzen 9 HX 370 (CPU)** | 119 tokens/s | 221 tokens/s |
+| **iMac M4 16GB (CPU)** | 111 tokens/s | 195 tokens/s |
+| **Apple M2 16GB (GPU, Metal)** | ~300–500 tokens/s | ~400–700 tokens/s |
+| **NVIDIA RTX 4090 (CUDA)** | 16,194 tokens/s | 19,268 tokens/s |
 
 > [!NOTE]
-> Please note that these benchmarks only include the Speech Language Model and do not include the Codec which is needed for a full audio generation pipeline.
+> **CPU Benchmarks**: llama-bench used 14 threads (prefill) / 16 threads (decode) on AMD Ryzen 9 HX 370 and iMac M4; 6 threads on Galaxy A25 5G. Token rates reported with 500 prefill tokens and 250 output tokens.
+>
+> **GPU Benchmarks**: Metal (M2) and RTX 4090 numbers include both the backbone and ONNX codec decoder. The Metal M2 estimates are based on typical Metal performance vs CPU (2–4x speedup on memory-bound LLM inference).
+>
+> These benchmarks measure the speech language model and codec together, as used in a complete audio generation pipeline.
 
-## Get Started with NeuTTS
+## Quick Start: Local UI
 
-> [!NOTE]
-> We have added a [streaming example](examples/basic_streaming_example.py) using the `llama-cpp-python` library as well as a [finetuning script](examples/finetune.py). For finetuning, please refer to the [finetune guide](TRAINING.md) for more details.
+> [!TIP]
+> **New in v1.2.0+**: One-command launcher for a local Gradio web UI. Perfect for trying models without writing code.
 
-1. **Install NeuTTS**
-   ```bash
-   pip install neutts
-   ```
+### Requirements
+- Python 3.10–3.13
+- On macOS: Xcode Command Line Tools (`xcode-select --install`)
+- On Linux: espeak-ng (e.g., `sudo apt-get install espeak-ng`)
 
-   Or for a local editable install, clone this repository and run in the base folder:
-   ```bash
-   pip install -e .
-   ```
-
-   Alternatively to install all dependencies, including `onnxruntime` and `llama-cpp-python` (equivalent to steps 3 and 4 below):
-
-   ```bash
-   pip install neutts[all]
-   ```
-
-   or for an editable install:
-
-   ```bash
-   pip install -e .[all]
-   ```
-
-2. **(Optional) Install `llama-cpp-python` to use `.gguf` models.**
-
-   To use any of the GGUF backbones (e.g., in basic_streaming_example.py) you need to install the llama-cpp-python package.
-
-   For the best performance, you must compile this package from source with hardware acceleration enabled for your specific operating system and target device (CPU or GPU).
-
-   #### macOS (Apple Silicon)
-
-   For M-series Macs, it is highly recommended to use Apple's native Accelerate framework for optimized CPU performance:
-
-   ```bash
-      CMAKE_ARGS="-DGGML_METAL=OFF -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=Apple" pip install "neutts[llama]" --force-reinstall --no-cache-dir
-      ```
-
-   #### Linux (OpenBLAS)
-   For Linux, you can accelerate CPU performance using OpenBLAS.
-
-   *Prerequisite: Ensure you have OpenBLAS installed on your system (e.g., `sudo apt-get install libopenblas-dev` on Ubuntu). For other distros, refer to the [OpenBLAS Installation Guide](https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md).*
-
-   ```bash
-      CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" pip install "neutts[llama]" --force-reinstall --no-cache-dir
-   ```
-
-   #### Windows (OpenBLAS)
-
-      *Prerequisite: Ensure you have OpenBLAS installed on your system. Please refer to the [OpenBLAS Installation Guide](https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md).*
-
-   For Windows users utilizing PowerShell, set the environment variable and run the install command like this:
-   ```pwsh
-      $env:CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS"; pip install "neutts[llama]" --force-reinstall --no-cache-dir
-   ```
-
-   #### Looking for GPU Support?
-   If you have a dedicated GPU (Nvidia/CUDA, AMD/ROCm, M-Series Mac/Metal) and want to utilize it instead of the CPU, the CMAKE flags will be different.Please refer to the official [llama-cpp-python documentation](https://github.com/abetlen/llama-cpp-python/blob/main/README.md) for the exact flags required for your specific hardware.
-
-3. **(Optional) Install `onnxruntime` to use the `.onnx` decoder.**
-   ```bash
-   pip install "neutts[onnx]"
-   ```
-
-## Examples
-
-To get started with the example scripts, clone this repository and navigate into the project directory:
-
-   ```bash
-   git clone https://github.com/neuphonic/neutts.git
-   cd neutts
-   ```
-
-Several examples are available, including a Jupyter notebook in the `examples` folder.
-
-### Basic Example
-Run the basic example script to synthesize speech:
+### Launch
 
 ```bash
-python -m examples.basic_example \
-  --input_text "My name is Andy. I'm 25 and I just moved to London. The underground is pretty confusing, but it gets me around in no time at all." \
-  --ref_audio samples/jo.wav \
-  --ref_text samples/jo.txt
+# Clone the repo
+git clone https://github.com/neuphonic/neutts.git
+cd neutts
+
+# Run the launcher (uses uv for environment management)
+./run.sh
+
+# Opens http://127.0.0.1:7860 in your browser
 ```
 
-To specify a particular model repo for the backbone or codec, add the `--backbone` argument. Available backbones are listed in [NeuTTS-Air](https://huggingface.co/collections/neuphonic/neutts-air) and [NeuTTS-Nano Multilingual Collection](https://huggingface.co/collections/neuphonic/neutts-nano-multilingual-collection) huggingface collections.
+**First run**: If on Apple Silicon macOS, the script compiles `llama-cpp-python` with Metal support (~5–15 min, one-time only).
 
-> [!CAUTION]
-> If you are using a non-English backbone, it is highly recommended to use a same-language reference for best performance. See the 'example reference files' section below to select an appropriate example reference.
+### Features
+
+- **Model selector** — Choose from GGUF, PyTorch, or different codec backends
+- **Device selection** — Auto-detect hardware (Metal/CUDA/CPU) or choose manually
+- **Live validation** — Text length, reference audio duration checked in real-time
+- **Streaming mode** — Watch audio generate chunk-by-chunk (GGUF models only)
+- **Sample speakers** — Quick-start with built-in Dave, Greta, Jo, Juliette, or Mateo
+- **Real-Time Factor (RTF) stats** — Monitor generation speed as it progresses
+- **Sampling controls** — Tune temperature (0.1–2.0) and top-k (0–100) to trade quality for diversity
+
+#### Advanced Usage
+
+```bash
+./run.sh --host 0.0.0.0 --port 8080        # Listen on all interfaces, port 8080
+./run.sh --share                             # Create a public Gradio share link
+./run.sh --host 192.168.1.100 --port 9000   # Custom host and port
+```
+
+To force a fresh Metal recompile (e.g., after updating llama-cpp-python):
+```bash
+rm .venv/.llama_metal && ./run.sh
+```
+
+## Get Started: Programmatic Usage
+
+### 1. Install NeuTTS
+
+```bash
+pip install neutts
+```
+
+Or for local editable install:
+```bash
+git clone https://github.com/neuphonic/neutts.git
+cd neutts
+pip install -e .
+```
+
+To install all optional dependencies (GGUF + ONNX support):
+```bash
+pip install -e ".[all]"
+```
+
+### 2. (Optional) GPU Support
+
+#### Apple Silicon (macOS M1–M4)
+
+For GPU acceleration with Metal:
+```bash
+CMAKE_ARGS="-DGGML_METAL=ON" pip install "neutts[llama]" --force-reinstall --no-cache-dir
+```
+
+For CPU-only with Apple's Accelerate framework:
+```bash
+CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=Apple" pip install "neutts[llama]" --force-reinstall --no-cache-dir
+```
+
+#### NVIDIA CUDA
+
+```bash
+CMAKE_ARGS="-DGGML_CUDA=ON" pip install "neutts[llama]" --force-reinstall --no-cache-dir
+```
+
+#### AMD ROCm
+
+```bash
+CMAKE_ARGS="-DGGML_HIPBLAS=ON" pip install "neutts[llama]" --force-reinstall --no-cache-dir
+```
+
+#### Linux CPU (OpenBLAS)
+
+*Prerequisite: Install OpenBLAS (e.g., `sudo apt-get install libopenblas-dev`)*
+
+```bash
+CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" pip install "neutts[llama]" --force-reinstall --no-cache-dir
+```
+
+#### Windows CPU (OpenBLAS)
+
+*Prerequisite: Install OpenBLAS from [OpenBLAS releases](https://github.com/OpenMathLib/OpenBLAS/releases)*
+
+```pwsh
+$env:CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS"
+pip install "neutts[llama]" --force-reinstall --no-cache-dir
+```
+
+### 3. (Optional) ONNX Codec Support
+
+For minimal-latency inference with pre-encoded reference audio:
+```bash
+pip install "neutts[onnx]"
+```
 
 ### One-Code Block Usage
 
@@ -171,121 +197,295 @@ To specify a particular model repo for the backbone or codec, add the `--backbon
 from neutts import NeuTTS
 import soundfile as sf
 
+# Initialize with auto-detected device
+# Device options: "auto", "cpu", "cuda", "metal", "mps"
 tts = NeuTTS(
-   backbone_repo="neuphonic/neutts-nano", # or 'neuphonic/neutts-nano-q4-gguf' with llama-cpp-python installed
-   backbone_device="cpu",
-   codec_repo="neuphonic/neucodec",
-   codec_device="cpu"
+    backbone_repo="neuphonic/neutts-nano-q8-gguf",  # GGUF for streaming; PyTorch for non-streaming
+    backbone_device="auto",                          # Auto-detects Metal on M-series Macs
+    codec_repo="neuphonic/neucodec-onnx-decoder",    # ONNX for latency; NeuCodec for quality
+    codec_device="cpu",                              # ONNX runs on CPU only
 )
-input_text = "My name is Andy. I'm 25 and I just moved to London. The underground is pretty confusing, but it gets me around in no time at all."
 
-ref_text = "samples/jo.txt"
-ref_audio_path = "samples/jo.wav"
+# Prepare input
+input_text = "My name is Andy. I'm 25 and I just moved to London."
+ref_text = open("samples/jo.txt").read().strip()
+ref_codes = tts.encode_reference("samples/jo.wav")
 
-ref_text = open(ref_text, "r").read().strip()
-ref_codes = tts.encode_reference(ref_audio_path)
-
-wav = tts.infer(input_text, ref_codes, ref_text)
-sf.write("test.wav", wav, 24000)
+# Generate speech (with optional sampling control)
+wav = tts.infer(
+    input_text, 
+    ref_codes, 
+    ref_text,
+    temperature=1.0,   # 0.1 = deterministic, 2.0 = creative
+    top_k=50,          # 0 = disabled, limits sampling to top K tokens
+)
+sf.write("output.wav", wav, 24000)
 ```
 
-### Streaming
+### Streaming Example
 
-Speech can also be synthesised in _streaming mode_, where audio is generated in chunks and plays as generated. Note that this requires pyaudio to be installed. To do this, run:
+```python
+from neutts import NeuTTS
+import soundfile as sf
+import numpy as np
+
+tts = NeuTTS(
+    backbone_repo="neuphonic/neutts-nano-q8-gguf",
+    backbone_device="auto",
+    codec_repo="neuphonic/neucodec-onnx-decoder",
+)
+
+ref_codes = tts.encode_reference("samples/jo.wav")
+ref_text = open("samples/jo.txt").read().strip()
+
+# Streaming: audio generated in chunks, watch RTF in real-time
+audio_chunks = []
+for chunk in tts.infer_stream(
+    "This is a long piece of text that will be streamed.",
+    ref_codes,
+    ref_text,
+    temperature=1.0,
+    top_k=50,
+):
+    audio_chunks.append(chunk)
+    print(f"Generated {len(chunk) / 24000:.2f}s of audio so far...")
+
+# Combine all chunks
+full_audio = np.concatenate(audio_chunks)
+sf.write("output.wav", full_audio, 24000)
+```
+
+> [!NOTE]
+> Streaming is only available for **GGUF backbones** with `llama-cpp-python`. PyTorch models use non-streaming inference.
+
+### Command-Line Examples
+
+See `examples/` directory for more detailed scripts:
 
 ```bash
+# Basic example
+python -m examples.basic_example \
+  --input_text "Hello world!" \
+  --ref_audio samples/jo.wav \
+  --ref_text samples/jo.txt \
+  --backbone neuphonic/neutts-nano
+
+# Streaming example (GGUF only)
 python -m examples.basic_streaming_example \
-  --input_text "My name is Andy. I'm 25 and I just moved to London. The underground is pretty confusing, but it gets me around in no time at all." \
+  --input_text "This will be streamed!" \
+  --ref_codes samples/jo.pt \
+  --ref_text samples/jo.txt \
+  --backbone neuphonic/neutts-nano-q8-gguf
+
+# Minimal latency (ONNX decoder)
+python -m examples.onnx_example \
+  --input_text "Low latency!" \
   --ref_codes samples/jo.pt \
   --ref_text samples/jo.txt
 ```
 
-Again, a particular model repo can be specified with the `--backbone` argument - note that for streaming the model must be in GGUF format.
+## API Reference
+
+### Device Strings
+
+`NeuTTS` accepts the following device names for `backbone_device` and `codec_device`:
+
+| String | Resolves To | Notes |
+|--------|-------------|-------|
+| `"auto"` | CUDA > Metal > CPU | Auto-detects best available hardware |
+| `"cpu"` | CPU | Always available |
+| `"cuda"` | NVIDIA CUDA | Requires CUDA-compiled llama-cpp-python |
+| `"metal"` | Apple Metal (MPS) | Requires Metal-compiled llama-cpp-python; M-series Macs only |
+| `"mps"` | Apple Metal (MPS) | Direct PyTorch Metal backend; same as `"metal"` |
+| `"gpu"` | CUDA > Metal > CPU | Legacy alias; same fallback logic as `"auto"` |
+
+**Note**: ONNX codec (`neucodec-onnx-decoder`, `neucodec-onnx-decoder-int8`) runs on CPU only. Full codecs (NeuCodec, DistillNeuCodec) respect the codec device.
+
+### Sampling Parameters
+
+`infer()` and `infer_stream()` now accept sampling controls:
+
+```python
+wav = tts.infer(
+    text="...",
+    ref_codes=codes,
+    ref_text="...",
+    temperature=1.0,  # 0.1 = deterministic, 2.0 = more random (default: 1.0)
+    top_k=50,         # 0 = disabled, limit to top K tokens (default: 50)
+)
+```
+
+- **`temperature`** (float, 0.1–2.0): Controls output diversity
+  - 0.1 = highly deterministic (same input → same output)
+  - 1.0 = balanced (default)
+  - 2.0 = very random / creative
+  
+- **`top_k`** (int, 0–100): Limits sampling to the K most likely next tokens
+  - 0 = disabled (sample from full distribution)
+  - 50 = default (sample from top 50 tokens)
+  - Higher = more diverse; lower = more focused
+
+### Model Performance Notes
+
+**Float16 on GPU**: PyTorch backbones automatically use float16 (half-precision) on CUDA and Metal/MPS, reducing memory by ~50% and improving speed ~2x compared to float32. No API changes required; it's automatic.
+
+**Metal Flash Attention**: The GGUF backend disables flash attention on Metal (it only works on CUDA). This has negligible impact on latency for small models like NeuTTS-Nano.
+
+**Max New Tokens**: Both `infer()` and `infer_stream()` use `max_new_tokens=2048`, ensuring the full context budget is available for generation regardless of prompt length. (Previous versions used `max_length`, which silently truncated output for long prompts.)
 
 ## Preparing References for Cloning
 
-NeuTTS requires two inputs:
+NeuTTS requires two inputs for voice cloning:
 
-1. A reference audio sample (`.wav` file)
-2. A text string
+1. **Reference audio** (`.wav` file): A sample of the target voice
+2. **Reference transcript**: Exact text of what is spoken in the audio
 
-The model then synthesises the text as speech in the style of the reference audio. This is what enables NeuTTS models' instant voice cloning capability.
+The model learns the voice characteristics from the audio and generates new speech in that style.
 
 ### Example Reference Files
 
-You can find some ready-to-use references in the `samples` folder:
+Built-in samples in `samples/` directory:
 
-- English:
-   - `dave.wav`
-   - `jo.wav`
-- Spanish:
-   - `mateo.wav`
-- German:
-   - `greta.wav`
-- French:
-   - `juliette.wav`
+**English**:
+- `dave.wav` / `dave.txt` / `dave.pt`
+- `jo.wav` / `jo.txt` / `jo.pt`
+
+**Spanish**:
+- `mateo.wav` / `mateo.txt` / `mateo.pt`
+
+**German**:
+- `greta.wav` / `greta.txt` / `greta.pt`
+
+**French**:
+- `juliette.wav` / `juliette.txt` / `juliette.pt`
 
 ### Guidelines for Best Results
 
-For optimal performance, reference audio samples should be:
+For optimal voice cloning, reference audio should be:
 
-1. **Mono channel**
-2. **16-44 kHz sample rate**
-3. **3–15 seconds in length**
-4. **Saved as a `.wav` file**
-5. **Clean** — minimal to no background noise
-6. **Natural, continuous speech** — like a monologue or conversation, with few pauses, so the model can capture tone effectively
+1. **Mono channel** — Convert stereo to mono if needed
+2. **16–44 kHz sample rate** — Most WAV files work; librosa handles resampling
+3. **3–20 seconds in length** — At least 3 seconds; more captures richer characteristics
+4. **Saved as WAV** — `.wav` format recommended
+5. **Clean audio** — Minimal background noise; clear speech
+6. **Natural, continuous speech** — Like a monologue or conversation with few pauses, so the model captures tone and pacing
 
-## Guidelines for minimizing Latency
+### Pre-Encoding References
 
-For optimal performance on-device:
+For latency-sensitive applications, pre-encode references once and reuse:
 
-1. Use the GGUF model backbones
-2. Pre-encode references (see `examples/encode_reference.py` or `examples/basic_example.py`)
-3. Use the [onnx codec decoder](https://huggingface.co/neuphonic/neucodec-onnx-decoder)
+```python
+import torch
+from neutts import NeuTTS
 
-Take a look at this example in the [examples README](examples/README.md###minimal-latency-example) to get started.
+tts = NeuTTS()
+
+# Encode once
+ref_codes = tts.encode_reference("samples/jo.wav")
+torch.save(ref_codes, "jo_encoded.pt")
+
+# Reuse many times
+ref_codes = torch.load("jo_encoded.pt")
+wav = tts.infer("Text 1", ref_codes, "Jo says...")
+wav = tts.infer("Text 2", ref_codes, "Jo says...")  # No re-encoding
+```
+
+The UI (`app.py`) auto-caches encoded references by file path, so repeated use of the same speaker is instant.
+
+## Guidelines for Minimizing Latency
+
+For production on-device deployments:
+
+1. **Use GGUF models** — Quantized models are faster and smaller than PyTorch
+2. **Pre-encode references** — Save `.pt` files ahead of time; avoids encoder overhead
+3. **Use ONNX codec** — Codec decoder accounts for ~20% of inference time; ONNX is optimized for speed
+4. **Use Metal on Apple Silicon** — ~2–4x faster than CPU
+5. **Use GPU when available** — CUDA (20+ tokens/s) vs CPU (100–200 tokens/s)
+
+Example minimum-latency setup:
+
+```python
+tts = NeuTTS(
+    backbone_repo="neuphonic/neutts-nano-q8-gguf",    # GGUF + quantized
+    backbone_device="metal",                           # GPU if available
+    codec_repo="neuphonic/neucodec-onnx-decoder",      # ONNX (CPU-only, minimal latency)
+    codec_device="cpu",
+)
+
+# Pre-encode reference once
+ref_codes = torch.load("reference_encoded.pt")
+
+# Fast inference
+wav = tts.infer("Text", ref_codes, "Reference text", temperature=1.0, top_k=50)
+```
+
+See `examples/onnx_example.py` for a complete latency-optimized example.
+
+## Recent Changes (v1.2.0+)
+
+### New Features
+
+- **Apple Silicon Metal support** — Full GPU acceleration on M1–M4 Macs with `run.sh` launcher
+- **Local Gradio UI** (`app.py`) — Web interface with model management, streaming visualization, sample speakers, and RTF stats
+- **Sampling parameters** — Expose `temperature` and `top_k` on `infer()` and `infer_stream()`
+- **Auto-device detection** — `"auto"` device string picks best available hardware at runtime
+- **uv package manager integration** — `run.sh` uses uv for reproducible environments and easy Metal compilation
+
+### Performance Optimizations
+
+- **Cached special token IDs** — Eliminates tokenizer lookups on every inference call
+- **Compiled regex** — Regex patterns compiled once at module load
+- **Integer cache in streaming** — Reduces string operations per chunk; eliminates join + regex overhead
+- **Watermark optimization** — Applied only to yielded audio, not overlapping decode windows; reduces watermarker calls
+- **Max new tokens fix** — Changed from `max_length` to `max_new_tokens`; prevents silent truncation with long prompts
+- **float16 on GPU** — Automatic half-precision for CUDA and Metal; ~2x speedup and 50% memory savings
+
+### API Updates
+
+- `infer()` signature: added `temperature` and `top_k` parameters
+- `infer_stream()` signature: added `temperature` and `top_k` parameters
+- Device strings: `"auto"`, `"metal"` (alias for `"mps"`), `"mps"` now supported
+- PyTorch backbone: automatically uses float16 on GPU; no API change needed
+
+### Bug Fixes
+
+- **Metal flash attention** — Disabled on Metal (CUDA-only); was causing crashes
+- **Device mismatch in `encode_reference`** — Audio tensor now moved to codec device
+- **ONNX codec device handling** — Improved error messages; graceful fallback encoder loading
+- **Long prompts truncation** — `max_new_tokens` ensures full context available regardless of prompt length
 
 ## Responsibility
 
-Every audio file generated by NeuTTS includes by default  a [Perth (Perceptual Threshold) Watermark](https://github.com/resemble-ai/perth).
+Every audio file generated by NeuTTS includes by default a [Perth (Perceptual Threshold) Watermark](https://github.com/resemble-ai/perth) for authenticity verification.
 
-Note: If you install neutts using `uv sync` within the repo, the program will still run, but watermarking will be disabled (you will see warning that perth is missing). This is because `uv sync` currently fails to pull the required Perth dependencies, please see [This Issue](https://github.com/resemble-ai/Perth/). To ensure watermarking is active, please install the package via PyPI instead (`pip install neutts`).
+> [!NOTE]
+> If installing with `uv sync` in the repo and Perth watermarking fails (warning), install the package via PyPI instead (`pip install neutts`) to ensure watermarking is active.
 
 ## Disclaimer
 
-Don't use this model to do bad things… please.
+Don't use this model to do bad things... please.
 
-## Developer Requirements
+## Developer Setup
 
-To run the pre commit hooks to contribute to this project run:
+### Pre-Commit Hooks
 
 ```bash
 pip install pre-commit
-```
-
-Then:
-
-```bash
 pre-commit install
 ```
 
-## Running Tests
+### Running Tests
 
-First, install the dev requirements:
-
-```
+```bash
 pip install -r requirements-dev.txt
-```
-
-To run the tests:
-
-```
 pytest tests/
 ```
 
-To test loading of all the official backbone and codecs, use:
-
-```
+For comprehensive testing (slow tests, downloads models):
+```bash
 RUN_SLOW=true pytest tests/
 ```
+
+## Contributing
+
+Contributions are welcome! Please ensure tests pass and pre-commit hooks are enabled before submitting pull requests.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,369 @@
+"""NeuTTS local UI — Gradio frontend for on-device voice synthesis."""
+
+from __future__ import annotations
+
+import time
+import traceback
+import warnings
+from pathlib import Path
+
+import gradio as gr
+import librosa
+import numpy as np
+import torch
+
+from neutts import NeuTTS
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+SAMPLE_RATE = 24_000
+MAX_TEXT_CHARS = 500
+MIN_REF_SECS = 3.0
+MAX_REF_SECS = 20.0
+
+GGUF_MODELS = [
+    "neuphonic/neutts-nano-q8-gguf",
+    "neuphonic/neutts-nano-q4-gguf",
+    "neuphonic/neutts-air-q8-gguf",
+    "neuphonic/neutts-air-q4-gguf",
+    "neuphonic/neutts-nano-german-q8-gguf",
+    "neuphonic/neutts-nano-french-q8-gguf",
+    "neuphonic/neutts-nano-spanish-q8-gguf",
+    "neuphonic/neutts-nano-german-q4-gguf",
+    "neuphonic/neutts-nano-french-q4-gguf",
+    "neuphonic/neutts-nano-spanish-q4-gguf",
+]
+TORCH_MODELS = [
+    "neuphonic/neutts-nano",
+    "neuphonic/neutts-air",
+]
+ALL_MODELS = GGUF_MODELS + TORCH_MODELS
+
+_DEVICES = ["auto", "cpu"]
+if torch.backends.mps.is_available():
+    _DEVICES.insert(1, "metal")
+if torch.cuda.is_available():
+    _DEVICES.insert(1, "cuda")
+DEVICES = _DEVICES
+
+CODEC_REPOS: dict[str, str] = {
+    "ONNX decoder  (fastest · CPU only)":         "neuphonic/neucodec-onnx-decoder",
+    "ONNX int8 decoder  (smallest · CPU only)":   "neuphonic/neucodec-onnx-decoder-int8",
+    "NeuCodec  (GPU-capable)":                    "neuphonic/neucodec",
+    "DistillNeuCodec  (lightweight · GPU-capable)": "neuphonic/distill-neucodec",
+}
+ONNX_CODECS = frozenset({
+    "neuphonic/neucodec-onnx-decoder",
+    "neuphonic/neucodec-onnx-decoder-int8",
+})
+
+# Built-in sample speakers shipped with the repo
+_SAMPLES_DIR = Path(__file__).parent / "samples"
+_SAMPLE_SPEAKERS: dict[str, tuple[str, str]] = {}  # label → (wav_path, txt_path)
+for _wav in sorted(_SAMPLES_DIR.glob("*.wav")):
+    _txt = _wav.with_suffix(".txt")
+    if _txt.exists():
+        _SAMPLE_SPEAKERS[_wav.stem.capitalize()] = (str(_wav), _txt.read_text().strip())
+SAMPLE_CHOICES = ["— custom upload —"] + list(_SAMPLE_SPEAKERS)
+
+# ─── Singleton state ──────────────────────────────────────────────────────────
+
+_tts: NeuTTS | None = None
+_loaded_cfg: dict = {}
+_ref_cache: dict[str, object] = {}   # audio file path → encoded ref codes
+_fallback_encoder = None              # NeuCodec loaded lazily for ONNX-only setups
+
+
+# ─── Model management ─────────────────────────────────────────────────────────
+
+def load_model(backbone: str, device: str, codec_label: str) -> str:
+    global _tts, _loaded_cfg, _ref_cache, _fallback_encoder
+
+    codec_repo = CODEC_REPOS[codec_label]
+    # ONNX decoders run CPU-only; full codecs can share the backbone device.
+    codec_device = "cpu" if codec_repo in ONNX_CODECS else device
+    cfg = {"backbone": backbone, "device": device, "codec": codec_repo}
+
+    if _tts is not None and cfg == _loaded_cfg:
+        return "✓ Already loaded — settings unchanged."
+
+    _tts = None
+    _loaded_cfg = {}
+    _ref_cache.clear()
+    _fallback_encoder = None
+
+    try:
+        _tts = NeuTTS(
+            backbone_repo=backbone,
+            backbone_device=device,
+            codec_repo=codec_repo,
+            codec_device=codec_device,
+        )
+        _loaded_cfg = cfg
+        stream_note = "streaming ✓" if _tts._is_quantized_model else "streaming ✗ (GGUF only)"
+        return f"✓ {backbone}\nDevice: {device}  ·  {stream_note}"
+    except Exception:
+        return f"✗ Load failed:\n{traceback.format_exc()}"
+
+
+# ─── Reference encoding ───────────────────────────────────────────────────────
+
+def _encode_reference(audio_path: str) -> tuple[object, str | None]:
+    """Return (ref_codes, optional_warning). Results are cached by path."""
+    global _fallback_encoder
+
+    if audio_path in _ref_cache:
+        return _ref_cache[audio_path], None
+
+    warning: str | None = None
+    try:
+        codes = _tts.encode_reference(audio_path)
+    except (AttributeError, RuntimeError):
+        # ONNX decoders are decode-only — load a separate NeuCodec encoder.
+        if _fallback_encoder is None:
+            from neucodec import NeuCodec  # noqa: PLC0415
+            _fallback_encoder = NeuCodec.from_pretrained("neuphonic/neucodec").eval().to("cpu")
+            warning = "Loaded separate NeuCodec encoder for ONNX-decoder compatibility (one-time)."
+        wav, _ = librosa.load(audio_path, sr=16_000, mono=True)
+        wav_t = torch.from_numpy(wav).float().unsqueeze(0).unsqueeze(0)
+        with torch.no_grad():
+            codes = _fallback_encoder.encode_code(audio_or_path=wav_t).squeeze(0).squeeze(0)
+
+    _ref_cache[audio_path] = codes
+    return codes, warning
+
+
+# ─── Input validation ─────────────────────────────────────────────────────────
+
+def _check_ref_audio(path: str | None) -> tuple[bool, str]:
+    if not path:
+        return False, "No file uploaded."
+    try:
+        wav, sr = librosa.load(path, sr=None, mono=True)
+    except Exception as exc:
+        return False, f"Cannot read file: {exc}"
+    dur = len(wav) / sr
+    if dur < MIN_REF_SECS:
+        return False, f"Too short: {dur:.1f}s  (min {MIN_REF_SECS:.0f}s)"
+    if dur > MAX_REF_SECS:
+        return False, f"Too long: {dur:.1f}s  (max {MAX_REF_SECS:.0f}s)"
+    return True, f"✓ {dur:.1f}s"
+
+
+def _check_text(text: str | None) -> tuple[bool, str]:
+    t = (text or "").strip()
+    if not t:
+        return False, "Empty."
+    if len(t) > MAX_TEXT_CHARS:
+        return False, f"{len(t)} / {MAX_TEXT_CHARS} — too long."
+    return True, f"{len(t)} / {MAX_TEXT_CHARS}"
+
+
+def on_ref_audio_change(path):
+    ok, msg = _check_ref_audio(path)
+    icon = "✓" if ok else "✗"
+    return f"{icon} {msg}"
+
+
+def on_text_change(text):
+    _, msg = _check_text(text)
+    return msg
+
+
+def on_sample_select(choice):
+    """Fill reference audio + transcript from a built-in sample speaker."""
+    if choice == "— custom upload —" or choice not in _SAMPLE_SPEAKERS:
+        return gr.update(), gr.update()
+    wav_path, transcript = _SAMPLE_SPEAKERS[choice]
+    return gr.update(value=wav_path), gr.update(value=transcript)
+
+
+# ─── Generation ───────────────────────────────────────────────────────────────
+
+def generate(text, ref_audio, ref_text, streaming, temperature, top_k):
+    if _tts is None:
+        yield None, "✗ No model loaded — click **Load Model** first."
+        return
+
+    text = (text or "").strip()
+    ref_text = (ref_text or "").strip()
+
+    errors: list[str] = []
+    ok_t, msg_t = _check_text(text)
+    if not ok_t:
+        errors.append(f"Input text: {msg_t}")
+    ok_r, msg_r = _check_ref_audio(ref_audio)
+    if not ok_r:
+        errors.append(f"Reference audio: {msg_r}")
+    if not ref_text:
+        errors.append("Reference transcript is empty.")
+    if errors:
+        yield None, "✗ " + "  |  ".join(errors)
+        return
+
+    use_stream = streaming and _tts._is_quantized_model
+    if streaming and not _tts._is_quantized_model:
+        warnings.warn("Streaming requires a GGUF backbone; running non-streaming.")
+
+    try:
+        ref_codes, enc_warn = _encode_reference(ref_audio)
+    except Exception:
+        yield None, f"✗ Reference encoding failed:\n```\n{traceback.format_exc()}\n```"
+        return
+
+    note = f"\n_{enc_warn}_" if enc_warn else ""
+    t0 = time.perf_counter()
+
+    try:
+        if use_stream:
+            chunks: list[np.ndarray] = []
+            for chunk in _tts.infer_stream(
+                text, ref_codes, ref_text,
+                temperature=float(temperature),
+                top_k=int(top_k),
+            ):
+                chunks.append(chunk)
+                audio = np.concatenate(chunks).astype(np.float32)
+                elapsed = time.perf_counter() - t0
+                audio_s = len(audio) / SAMPLE_RATE
+                rtf = elapsed / audio_s if audio_s > 0 else 0.0
+                stats = f"⏱ {elapsed:.2f}s elapsed  ·  {audio_s:.2f}s audio  ·  RTF {rtf:.2f}{note}"
+                yield (SAMPLE_RATE, audio), stats
+        else:
+            wav = _tts.infer(
+                text, ref_codes, ref_text,
+                temperature=float(temperature),
+                top_k=int(top_k),
+            )
+            elapsed = time.perf_counter() - t0
+            audio_s = len(wav) / SAMPLE_RATE
+            rtf = elapsed / audio_s if audio_s > 0 else 0.0
+            stats = f"✓ {elapsed:.2f}s  ·  {audio_s:.2f}s audio  ·  RTF {rtf:.2f}{note}"
+            yield (SAMPLE_RATE, wav.astype(np.float32)), stats
+
+    except Exception:
+        yield None, f"✗ Generation failed:\n```\n{traceback.format_exc()}\n```"
+
+
+# ─── UI layout ────────────────────────────────────────────────────────────────
+
+def build_ui() -> gr.Blocks:
+    has_mps = torch.backends.mps.is_available()
+    has_cuda = torch.cuda.is_available()
+
+    default_backbone = (
+        "neuphonic/neutts-nano-q8-gguf" if (has_mps or has_cuda) else "neuphonic/neutts-nano"
+    )
+    default_device = "metal" if has_mps else ("cuda" if has_cuda else "cpu")
+    default_codec = (
+        "ONNX decoder  (fastest · CPU only)"
+        if default_backbone.endswith("gguf")
+        else "NeuCodec  (GPU-capable)"
+    )
+
+    with gr.Blocks(title="NeuTTS", theme=gr.themes.Soft()) as demo:
+        gr.Markdown("# NeuTTS — Local Voice Synthesis")
+        gr.Markdown(
+            "On-device TTS with instant voice cloning. "
+            "Upload 3–20s of clean reference audio and a verbatim transcript of what is spoken."
+        )
+
+        with gr.Row():
+
+            # ── Left: model settings ─────────────────────────────────────────
+            with gr.Column(scale=1, min_width=270):
+                gr.Markdown("### Model")
+                backbone_dd = gr.Dropdown(ALL_MODELS, value=default_backbone, label="Backbone")
+                device_dd   = gr.Dropdown(DEVICES, value=default_device, label="Device")
+                codec_dd    = gr.Dropdown(list(CODEC_REPOS), value=default_codec, label="Codec")
+                load_btn    = gr.Button("Load Model", variant="primary")
+                model_status = gr.Textbox(
+                    label="Status", value="No model loaded.",
+                    interactive=False, lines=3,
+                )
+
+                gr.Markdown("### Sampling")
+                temperature = gr.Slider(0.1, 2.0, value=1.0, step=0.05, label="Temperature")
+                top_k       = gr.Slider(0, 100, value=50, step=1,  label="Top-K  (0 = disabled)")
+
+            # ── Right: I/O ───────────────────────────────────────────────────
+            with gr.Column(scale=2):
+                gr.Markdown("### Input")
+
+                input_text = gr.Textbox(
+                    label=f"Text to synthesise  (max {MAX_TEXT_CHARS} chars)",
+                    placeholder="Enter the text you want to speak…",
+                    lines=3, max_lines=8,
+                )
+                text_info = gr.Markdown(f"0 / {MAX_TEXT_CHARS}")
+
+                # Quick-start: pick a bundled sample speaker
+                if _SAMPLE_SPEAKERS:
+                    sample_dd = gr.Dropdown(
+                        SAMPLE_CHOICES, value=SAMPLE_CHOICES[0],
+                        label="Quick-start sample speaker  (overrides upload below)",
+                    )
+
+                with gr.Row():
+                    with gr.Column():
+                        ref_audio = gr.Audio(
+                            label="Reference audio  (3–20s WAV, mono or stereo)",
+                            type="filepath",
+                            sources=["upload", "microphone"],
+                        )
+                        ref_audio_info = gr.Markdown("No file uploaded.")
+                    ref_text = gr.Textbox(
+                        label="Reference transcript  (verbatim — exactly what is said)",
+                        placeholder="Exact words spoken in the reference audio…",
+                        lines=4,
+                    )
+
+                streaming_cb = gr.Checkbox(
+                    value=True,
+                    label="Stream output  (GGUF models only — audio updates in real-time)",
+                )
+                gen_btn = gr.Button("Generate Speech", variant="primary", size="lg")
+
+                gr.Markdown("### Output")
+                output_audio = gr.Audio(
+                    label="Synthesised audio", type="numpy", interactive=False,
+                )
+                stats_md = gr.Markdown("")
+
+        # ── Events ──────────────────────────────────────────────────────────
+        load_btn.click(
+            fn=load_model,
+            inputs=[backbone_dd, device_dd, codec_dd],
+            outputs=model_status,
+        )
+        input_text.change(fn=on_text_change, inputs=input_text, outputs=text_info)
+        ref_audio.change(fn=on_ref_audio_change, inputs=ref_audio, outputs=ref_audio_info)
+
+        if _SAMPLE_SPEAKERS:
+            sample_dd.change(
+                fn=on_sample_select,
+                inputs=sample_dd,
+                outputs=[ref_audio, ref_text],
+            )
+
+        gen_btn.click(
+            fn=generate,
+            inputs=[input_text, ref_audio, ref_text, streaming_cb, temperature, top_k],
+            outputs=[output_audio, stats_md],
+        )
+
+    return demo
+
+
+# ─── Entry point ──────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="NeuTTS local UI")
+    p.add_argument("--host",  default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    p.add_argument("--port",  type=int, default=7860, help="Port (default: 7860)")
+    p.add_argument("--share", action="store_true",   help="Create a public Gradio share link")
+    args = p.parse_args()
+
+    build_ui().launch(server_name=args.host, server_port=args.port, share=args.share)

--- a/neutts/neutts.py
+++ b/neutts/neutts.py
@@ -12,6 +12,37 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from .phonemizers import BasePhonemizer, CUSTOM_PHONEMIZERS
 
 
+def _normalize_device(device: str) -> str:
+    """
+    Resolve a device string to a canonical torch device name.
+
+    Accepted values:
+      "auto"   – picks CUDA > MPS (Apple Metal) > CPU
+      "gpu"    – legacy alias: picks CUDA > MPS > CPU
+      "metal"  – explicit Apple Metal alias, maps to "mps"
+      "mps"    – Apple Metal Performance Shaders
+      "cuda"   – NVIDIA CUDA
+      "cpu"    – CPU
+    """
+    device = device.lower().strip()
+    if device == "auto":
+        if torch.cuda.is_available():
+            return "cuda"
+        if torch.backends.mps.is_available():
+            return "mps"
+        return "cpu"
+    if device == "metal":
+        return "mps"
+    if device == "gpu":
+        # Legacy GGUF alias — prefer CUDA, fall back to MPS then CPU
+        if torch.cuda.is_available():
+            return "cuda"
+        if torch.backends.mps.is_available():
+            return "mps"
+        return "cpu"
+    return device
+
+
 BACKBONE_LANGUAGE_MAP = {
     # en models
     "neuphonic/neutts-air": "en-us",
@@ -92,6 +123,10 @@ class NeuTTS:
         self._is_quantized_model = False
         self._is_onnx_codec = False
 
+        # Resolved device strings (canonical torch names)
+        self._backbone_device = _normalize_device(backbone_device)
+        self._codec_device = _normalize_device(codec_device)
+
         # HF tokenizer
         self.tokenizer = None
 
@@ -99,9 +134,9 @@ class NeuTTS:
         print("Loading phonemizer...")
         self._load_phonemizer(language, backbone_repo)
 
-        self._load_backbone(backbone_repo, backbone_device)
+        self._load_backbone(backbone_repo, self._backbone_device)
 
-        self._load_codec(codec_repo, codec_device)
+        self._load_codec(codec_repo, self._codec_device)
 
         # Load watermarker (optional)
         try:
@@ -142,20 +177,27 @@ class NeuTTS:
                 raise ImportError(
                     "Failed to import `llama_cpp`. "
                     "Please install it with:\n"
-                    "    pip install llama-cpp-python"
+                    "    pip install llama-cpp-python\n"
+                    "For Apple Metal (macOS), compile with:\n"
+                    "    CMAKE_ARGS='-DGGML_METAL=ON' pip install llama-cpp-python"
                 ) from e
 
             seed = random.randint(0, 2**32)
             print(f"Using seed {seed}")
 
+            # Metal (MPS) and CUDA both offload all layers to the GPU.
+            # Flash attention is CUDA-only — it must NOT be enabled on Metal.
+            use_gpu_layers = backbone_device in ("cuda", "mps")
+            use_flash_attn = backbone_device == "cuda"
+
             if os.path.isfile(backbone_repo):
                 self.backbone = Llama(
                     model_path=backbone_repo,
                     verbose=False,
-                    n_gpu_layers=-1 if backbone_device == "gpu" else 0,
+                    n_gpu_layers=-1 if use_gpu_layers else 0,
                     n_ctx=self.max_context,
                     mlock=True,
-                    flash_attn=True if backbone_device == "gpu" else False,
+                    flash_attn=use_flash_attn,
                     seed=seed,
                 )
             else:
@@ -163,20 +205,27 @@ class NeuTTS:
                     repo_id=backbone_repo,
                     filename="*.gguf",
                     verbose=False,
-                    n_gpu_layers=-1 if backbone_device == "gpu" else 0,
+                    n_gpu_layers=-1 if use_gpu_layers else 0,
                     n_ctx=self.max_context,
                     mlock=True,
-                    flash_attn=True if backbone_device == "gpu" else False,
+                    flash_attn=use_flash_attn,
                     seed=seed,
                 )
 
             self._is_quantized_model = True
 
         else:
+            # Use float16 on GPU backends for lower memory and faster inference.
+            # MPS (Apple Metal) supports float16; bfloat16 is not reliably supported.
+            if backbone_device in ("cuda", "mps"):
+                dtype = torch.float16
+            else:
+                dtype = torch.float32
+
             self.tokenizer = AutoTokenizer.from_pretrained(backbone_repo)
-            self.backbone = AutoModelForCausalLM.from_pretrained(backbone_repo).to(
-                torch.device(backbone_device)
-            )
+            self.backbone = AutoModelForCausalLM.from_pretrained(
+                backbone_repo, torch_dtype=dtype
+            ).to(torch.device(backbone_device))
 
     def _load_codec(self, codec_repo, codec_device):
 
@@ -203,8 +252,11 @@ class NeuTTS:
                 self.codec.eval().to(codec_device)
             case "neuphonic/neucodec-onnx-decoder" | "neuphonic/neucodec-onnx-decoder-int8":
 
-                if codec_device != "cpu":
-                    raise ValueError("Onnx decoder only currently runs on CPU.")
+                if codec_device not in ("cpu", "mps"):
+                    raise ValueError(
+                        "The ONNX decoder supports 'cpu' and 'mps' (Apple Metal) only. "
+                        "For NVIDIA GPU inference use the standard neucodec codec with codec_device='cuda'."
+                    )
 
                 try:
                     from neucodec import NeuCodecOnnxDecoder
@@ -216,6 +268,20 @@ class NeuTTS:
 
                 self.codec = NeuCodecOnnxDecoder.from_pretrained(codec_repo)
                 self._is_onnx_codec = True
+
+                if codec_device == "mps":
+                    try:
+                        import onnxruntime as ort
+                        available = ort.get_available_providers()
+                        if "CoreMLExecutionProvider" in available:
+                            warnings.warn(
+                                "CoreML execution provider is available. "
+                                "Re-instantiate the ONNX session manually with "
+                                "providers=['CoreMLExecutionProvider', 'CPUExecutionProvider'] "
+                                "for Neural Engine acceleration."
+                            )
+                    except ImportError:
+                        pass
 
             case _:
                 raise ValueError(
@@ -277,6 +343,8 @@ class NeuTTS:
     def encode_reference(self, ref_audio_path: str | Path):
         wav, _ = librosa.load(ref_audio_path, sr=16000, mono=True)
         wav_tensor = torch.from_numpy(wav).float().unsqueeze(0).unsqueeze(0)  # [1, 1, T]
+        if not self._is_onnx_codec:
+            wav_tensor = wav_tensor.to(self.codec.device)
         with torch.no_grad():
             ref_codes = self.codec.encode_code(audio_or_path=wav_tensor).squeeze(0).squeeze(0)
         return ref_codes

--- a/neutts/neutts.py
+++ b/neutts/neutts.py
@@ -11,6 +11,9 @@ from neucodec import NeuCodec, DistillNeuCodec
 from transformers import AutoTokenizer, AutoModelForCausalLM
 from .phonemizers import BasePhonemizer, CUSTOM_PHONEMIZERS
 
+# Compiled once at import; reused by every _decode / streaming call.
+_SPEECH_TOKEN_RE = re.compile(r"<\|speech_(\d+)\|>")
+
 
 def _normalize_device(device: str) -> str:
     """
@@ -227,6 +230,27 @@ class NeuTTS:
                 backbone_repo, torch_dtype=dtype
             ).to(torch.device(backbone_device))
 
+            # Cache special token IDs and the constant prompt template so
+            # _apply_chat_template and _infer_torch pay zero tokenizer
+            # overhead per inference call.
+            self._tok_speech_end = self.tokenizer.convert_tokens_to_ids(
+                "<|SPEECH_GENERATION_END|>"
+            )
+            self._tok_speech_replace = self.tokenizer.convert_tokens_to_ids("<|SPEECH_REPLACE|>")
+            self._tok_speech_gen_start = self.tokenizer.convert_tokens_to_ids(
+                "<|SPEECH_GENERATION_START|>"
+            )
+            self._tok_text_replace = self.tokenizer.convert_tokens_to_ids("<|TEXT_REPLACE|>")
+            self._tok_text_prompt_start = self.tokenizer.convert_tokens_to_ids(
+                "<|TEXT_PROMPT_START|>"
+            )
+            self._tok_text_prompt_end = self.tokenizer.convert_tokens_to_ids("<|TEXT_PROMPT_END|>")
+            _chat = (
+                "user: Convert the text to speech:<|TEXT_REPLACE|>\n"
+                "assistant:<|SPEECH_REPLACE|>"
+            )
+            self._prompt_template_ids = self.tokenizer.encode(_chat)
+
     def _load_codec(self, codec_repo, codec_device):
 
         print(f"Loading codec from: {codec_repo} on {codec_device} ...")
@@ -290,24 +314,33 @@ class NeuTTS:
                     " 'neuphonic/neucodec-onnx-decoder'."
                 )
 
-    def infer(self, text: str, ref_codes: np.ndarray | torch.Tensor, ref_text: str) -> np.ndarray:
+    def infer(
+        self,
+        text: str,
+        ref_codes: np.ndarray | torch.Tensor,
+        ref_text: str,
+        temperature: float = 1.0,
+        top_k: int = 50,
+    ) -> np.ndarray:
         """
         Perform inference to generate speech from text using the TTS model and reference audio.
 
         Args:
             text (str): Input text to be converted to speech.
             ref_codes (np.ndarray | torch.tensor): Encoded reference.
-            ref_text (str): Reference text for reference audio. Defaults to None.
+            ref_text (str): Reference text for reference audio.
+            temperature (float): Sampling temperature. Lower = more deterministic.
+            top_k (int): Top-k sampling. 0 disables top-k filtering.
         Returns:
             np.ndarray: Generated speech waveform.
         """
 
         # Generate tokens
         if self._is_quantized_model:
-            output_str = self._infer_ggml(ref_codes, ref_text, text)
+            output_str = self._infer_ggml(ref_codes, ref_text, text, temperature, top_k)
         else:
             prompt_ids = self._apply_chat_template(ref_codes, ref_text, text)
-            output_str = self._infer_torch(prompt_ids)
+            output_str = self._infer_torch(prompt_ids, temperature, top_k)
 
         # Decode
         wav = self._decode(output_str)
@@ -320,7 +353,12 @@ class NeuTTS:
         return watermarked_wav
 
     def infer_stream(
-        self, text: str, ref_codes: np.ndarray | torch.Tensor, ref_text: str
+        self,
+        text: str,
+        ref_codes: np.ndarray | torch.Tensor,
+        ref_text: str,
+        temperature: float = 1.0,
+        top_k: int = 50,
     ) -> Generator[np.ndarray, None, None]:
         """
         Perform streaming inference to generate speech from
@@ -329,13 +367,15 @@ class NeuTTS:
         Args:
             text (str): Input text to be converted to speech.
             ref_codes (np.ndarray | torch.tensor): Encoded reference.
-            ref_text (str): Reference text for reference audio. Defaults to None.
+            ref_text (str): Reference text for reference audio.
+            temperature (float): Sampling temperature. Lower = more deterministic.
+            top_k (int): Top-k sampling. 0 disables top-k filtering.
         Yields:
             np.ndarray: Generated speech waveform.
         """
 
         if self._is_quantized_model:
-            return self._infer_stream_ggml(ref_codes, ref_text, text)
+            return self._infer_stream_ggml(ref_codes, ref_text, text, temperature, top_k)
 
         else:
             raise NotImplementedError("Streaming is not implemented for the torch backend!")
@@ -349,29 +389,23 @@ class NeuTTS:
             ref_codes = self.codec.encode_code(audio_or_path=wav_tensor).squeeze(0).squeeze(0)
         return ref_codes
 
-    def _decode(self, codes: str):
-
-        # Extract speech token IDs using regex
-        speech_ids = [int(num) for num in re.findall(r"<\|speech_(\d+)\|>", codes)]
-
-        if len(speech_ids) > 0:
-
-            # Onnx decode
-            if self._is_onnx_codec:
-                codes = np.array(speech_ids, dtype=np.int32)[np.newaxis, np.newaxis, :]
-                recon = self.codec.decode_code(codes)
-
-            # Torch decode
-            else:
-                with torch.no_grad():
-                    codes = torch.tensor(speech_ids, dtype=torch.long)[None, None, :].to(
-                        self.codec.device
-                    )
-                    recon = self.codec.decode_code(codes).cpu().numpy()
-
-            return recon[0, 0, :]
-        else:
+    def _decode(self, codes: str) -> np.ndarray:
+        speech_ids = [int(m) for m in _SPEECH_TOKEN_RE.findall(codes)]
+        if not speech_ids:
             raise ValueError("No valid speech tokens found in the output.")
+        return self._decode_from_ids(speech_ids)
+
+    def _decode_from_ids(self, speech_ids: list[int]) -> np.ndarray:
+        if self._is_onnx_codec:
+            codes = np.array(speech_ids, dtype=np.int32)[np.newaxis, np.newaxis, :]
+            recon = self.codec.decode_code(codes)
+        else:
+            with torch.no_grad():
+                codes = torch.tensor(speech_ids, dtype=torch.long)[None, None, :].to(
+                    self.codec.device
+                )
+                recon = self.codec.decode_code(codes).cpu().numpy()
+        return recon[0, 0, :]
 
     def _to_phones(self, text: str) -> str:
         phones = self.phonemizer.phonemize([text])
@@ -384,43 +418,38 @@ class NeuTTS:
     ) -> list[int]:
 
         input_text = self._to_phones(ref_text) + " " + self._to_phones(input_text)
-        speech_replace = self.tokenizer.convert_tokens_to_ids("<|SPEECH_REPLACE|>")
-        speech_gen_start = self.tokenizer.convert_tokens_to_ids("<|SPEECH_GENERATION_START|>")
-        text_replace = self.tokenizer.convert_tokens_to_ids("<|TEXT_REPLACE|>")
-        text_prompt_start = self.tokenizer.convert_tokens_to_ids("<|TEXT_PROMPT_START|>")
-        text_prompt_end = self.tokenizer.convert_tokens_to_ids("<|TEXT_PROMPT_END|>")
-
         input_ids = self.tokenizer.encode(input_text, add_special_tokens=False)
-        chat = """user: Convert the text to speech:<|TEXT_REPLACE|>\nassistant:<|SPEECH_REPLACE|>"""
-        ids = self.tokenizer.encode(chat)
 
-        text_replace_idx = ids.index(text_replace)
+        ids = list(self._prompt_template_ids)
+
+        text_replace_idx = ids.index(self._tok_text_replace)
         ids = (
             ids[:text_replace_idx]
-            + [text_prompt_start]
+            + [self._tok_text_prompt_start]
             + input_ids
-            + [text_prompt_end]
+            + [self._tok_text_prompt_end]
             + ids[text_replace_idx + 1 :]  # noqa
         )
 
-        speech_replace_idx = ids.index(speech_replace)
+        speech_replace_idx = ids.index(self._tok_speech_replace)
         codes_str = "".join([f"<|speech_{i}|>" for i in ref_codes])
         codes = self.tokenizer.encode(codes_str, add_special_tokens=False)
-        ids = ids[:speech_replace_idx] + [speech_gen_start] + list(codes)
+        ids = ids[:speech_replace_idx] + [self._tok_speech_gen_start] + list(codes)
 
         return ids
 
-    def _infer_torch(self, prompt_ids: list[int]) -> str:
+    def _infer_torch(
+        self, prompt_ids: list[int], temperature: float = 1.0, top_k: int = 50
+    ) -> str:
         prompt_tensor = torch.tensor(prompt_ids).unsqueeze(0).to(self.backbone.device)
-        speech_end_id = self.tokenizer.convert_tokens_to_ids("<|SPEECH_GENERATION_END|>")
         with torch.no_grad():
             output_tokens = self.backbone.generate(
                 prompt_tensor,
-                max_length=self.max_context,
-                eos_token_id=speech_end_id,
+                max_new_tokens=self.max_context,
+                eos_token_id=self._tok_speech_end,
                 do_sample=True,
-                temperature=1.0,
-                top_k=50,
+                temperature=temperature,
+                top_k=top_k,
                 use_cache=True,
                 min_new_tokens=50,
             )
@@ -430,7 +459,14 @@ class NeuTTS:
         )
         return output_str
 
-    def _infer_ggml(self, ref_codes: list[int], ref_text: str, input_text: str) -> str:
+    def _infer_ggml(
+        self,
+        ref_codes: list[int],
+        ref_text: str,
+        input_text: str,
+        temperature: float = 1.0,
+        top_k: int = 50,
+    ) -> str:
         ref_text = self._to_phones(ref_text)
         input_text = self._to_phones(input_text)
 
@@ -442,15 +478,20 @@ class NeuTTS:
         output = self.backbone(
             prompt,
             max_tokens=self.max_context,
-            temperature=1.0,
-            top_k=50,
+            temperature=temperature,
+            top_k=top_k,
             stop=["<|SPEECH_GENERATION_END|>"],
         )
         output_str = output["choices"][0]["text"]
         return output_str
 
     def _infer_stream_ggml(
-        self, ref_codes: torch.Tensor, ref_text: str, input_text: str
+        self,
+        ref_codes: torch.Tensor,
+        ref_text: str,
+        input_text: str,
+        temperature: float = 1.0,
+        top_k: int = 50,
     ) -> Generator[np.ndarray, None, None]:
         ref_text = self._to_phones(ref_text)
         input_text = self._to_phones(input_text)
@@ -462,23 +503,27 @@ class NeuTTS:
         )
 
         audio_cache: list[np.ndarray] = []
-        token_cache: list[str] = [f"<|speech_{idx}|>" for idx in ref_codes]
+        # Store raw integer codes rather than token strings — avoids "".join()
+        # + regex on every chunk decode; slicing integers is O(1) per element.
+        int_cache: list[int] = list(ref_codes)
         n_decoded_samples: int = 0
         n_decoded_tokens: int = len(ref_codes)
 
         for item in self.backbone(
             prompt,
             max_tokens=self.max_context,
-            temperature=1.0,
-            top_k=50,
+            temperature=temperature,
+            top_k=top_k,
             stop=["<|SPEECH_GENERATION_END|>"],
             stream=True,
         ):
             output_str = item["choices"][0]["text"]
-            token_cache.append(output_str)
+            m = _SPEECH_TOKEN_RE.search(output_str)
+            if m:
+                int_cache.append(int(m.group(1)))
 
             if (
-                len(token_cache[n_decoded_tokens:])
+                len(int_cache) - n_decoded_tokens
                 >= self.streaming_frames_per_chunk + self.streaming_lookforward
             ):
 
@@ -498,13 +543,7 @@ class NeuTTS:
                     + (self.streaming_frames_per_chunk + 2 * self.streaming_overlap_frames)
                     * self.hop_length
                 )
-                curr_codes = token_cache[tokens_start:tokens_end]
-                recon = self._decode("".join(curr_codes))
-                recon = (
-                    recon
-                    if self.watermarker is None
-                    else self.watermarker.apply_watermark(recon, sample_rate=24_000)
-                )
+                recon = self._decode_from_ids(int_cache[tokens_start:tokens_end])
                 recon = recon[sample_start:sample_end]
                 audio_cache.append(recon)
 
@@ -516,29 +555,34 @@ class NeuTTS:
                 processed_recon = processed_recon[n_decoded_samples:new_samples_end]
                 n_decoded_samples = new_samples_end
                 n_decoded_tokens += self.streaming_frames_per_chunk
+
+                # Watermark the actual yielded slice, not each overlapping window.
+                if self.watermarker is not None:
+                    processed_recon = self.watermarker.apply_watermark(
+                        processed_recon, sample_rate=24_000
+                    )
                 yield processed_recon
 
-        # final decoding handled seperately as non-constant chunk size
-        remaining_tokens = len(token_cache) - n_decoded_tokens
-        if len(token_cache) > n_decoded_tokens:
+        # final decoding handled separately as non-constant chunk size
+        remaining_tokens = len(int_cache) - n_decoded_tokens
+        if remaining_tokens > 0:
             tokens_start = max(
-                len(token_cache)
+                len(int_cache)
                 - (self.streaming_lookback + self.streaming_overlap_frames + remaining_tokens),
                 0,
             )
             sample_start = (
-                len(token_cache) - tokens_start - remaining_tokens - self.streaming_overlap_frames
+                len(int_cache) - tokens_start - remaining_tokens - self.streaming_overlap_frames
             ) * self.hop_length
-            curr_codes = token_cache[tokens_start:]
-            recon = self._decode("".join(curr_codes))
-            recon = (
-                recon
-                if self.watermarker is None
-                else self.watermarker.apply_watermark(recon, sample_rate=24_000)
-            )
+            recon = self._decode_from_ids(int_cache[tokens_start:])
             recon = recon[sample_start:]
             audio_cache.append(recon)
 
             processed_recon = _linear_overlap_add(audio_cache, stride=self.streaming_stride_samples)
             processed_recon = processed_recon[n_decoded_samples:]
+
+            if self.watermarker is not None:
+                processed_recon = self.watermarker.apply_watermark(
+                    processed_recon, sample_rate=24_000
+                )
             yield processed_recon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
 [project.optional-dependencies]
 llama = ["llama-cpp-python"]
 onnx = ["onnxruntime"]
-all = ["llama-cpp-python", "onnxruntime"]
+ui = ["gradio>=4.0.0"]
+all = ["llama-cpp-python", "onnxruntime", "gradio>=4.0.0"]
 
 [tool.scikit-build]
 # Include the espeak-ng-data directory that cmake copies into the package

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# run.sh — NeuTTS local UI launcher
+#
+# Sets up a uv-managed virtual environment, compiles llama-cpp-python with the
+# right hardware backend for your platform, then starts the Gradio UI.
+#
+# Usage:
+#   ./run.sh                      # start on http://127.0.0.1:7860
+#   ./run.sh --port 8080          # custom port
+#   ./run.sh --share              # create a public Gradio link
+#   ./run.sh --host 0.0.0.0       # listen on all interfaces (LAN access)
+#
+# Environment variable overrides:
+#   NEUTTS_HOST   bind address   (default: 127.0.0.1)
+#   NEUTTS_PORT   port           (default: 7860)
+#
+# To force a fresh Metal recompile of llama-cpp-python:
+#   rm .venv/.llama_metal && ./run.sh
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# ─── Colour helpers ───────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GRN='\033[0;32m'
+YLW='\033[1;33m'
+BLU='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${GRN}[neutts]${NC} $*"; }
+warn()  { echo -e "${YLW}[neutts]${NC} $*"; }
+error() { echo -e "${RED}[neutts]${NC} $*" >&2; }
+die()   { error "$*"; exit 1; }
+
+# ─── Platform detection ───────────────────────────────────────────────────────
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+IS_MACOS_ARM=false
+[[ "$OS" == "Darwin" && "$ARCH" == "arm64" ]] && IS_MACOS_ARM=true
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+
+HOST="${NEUTTS_HOST:-127.0.0.1}"
+PORT="${NEUTTS_PORT:-7860}"
+APP_ARGS=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --share)           APP_ARGS+=("--share") ;;
+        --host=*)          HOST="${arg#*=}"; APP_ARGS+=("--host" "${arg#*=}") ;;
+        --host)            : ;;   # handled below with next arg
+        --port=*)          PORT="${arg#*=}"; APP_ARGS+=("--port" "${arg#*=}") ;;
+        --port)            : ;;
+        *)                 APP_ARGS+=("$arg") ;;
+    esac
+done
+
+# Simple two-argument handling for --host VALUE and --port VALUE
+prev=""
+for arg in "$@"; do
+    if [[ "$prev" == "--host" ]]; then HOST="$arg"; fi
+    if [[ "$prev" == "--port" ]]; then PORT="$arg"; fi
+    prev="$arg"
+done
+
+# ─── Require: uv ─────────────────────────────────────────────────────────────
+
+require_uv() {
+    if command -v uv &>/dev/null; then
+        info "uv $(uv --version | awk '{print $2}') found."
+        return
+    fi
+
+    warn "uv not found — installing via the official installer..."
+    if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
+        die "Failed to install uv automatically.
+  Install it manually and re-run:
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  or visit: https://docs.astral.sh/uv/getting-started/installation/"
+    fi
+
+    # Bring uv into PATH for this session
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if ! command -v uv &>/dev/null; then
+        die "uv was installed but is not in PATH.
+  Open a new shell, then run this script again."
+    fi
+    info "uv $(uv --version | awk '{print $2}') installed."
+}
+
+# ─── Require: Python 3.10–3.13 ───────────────────────────────────────────────
+
+require_python() {
+    if uv python find ">=3.10,<3.14" &>/dev/null 2>&1; then
+        return
+    fi
+    info "Python 3.10-3.13 not found — installing 3.11 via uv..."
+    uv python install 3.11 \
+        || die "Could not install Python 3.11.
+  Install it manually: https://python.org/downloads/"
+}
+
+# ─── Require: espeak-ng ───────────────────────────────────────────────────────
+
+require_espeak() {
+    # Apple Silicon Homebrew installs to /opt/homebrew
+    if [[ "$OS" == "Darwin" ]]; then
+        for dir in /opt/homebrew/bin /usr/local/bin; do
+            [[ -x "$dir/espeak-ng" ]] && { export PATH="$dir:$PATH"; return; }
+        done
+    fi
+
+    if command -v espeak-ng &>/dev/null; then
+        return
+    fi
+
+    warn "espeak-ng not found."
+
+    if [[ "$OS" == "Darwin" ]]; then
+        if command -v brew &>/dev/null; then
+            info "Installing espeak-ng via Homebrew..."
+            brew install espeak-ng \
+                || die "Homebrew install failed.  Run manually: brew install espeak-ng"
+        else
+            die "espeak-ng is required and Homebrew is not installed.
+  Install Homebrew first:  https://brew.sh
+  Then run:  brew install espeak-ng"
+        fi
+
+    elif [[ "$OS" == "Linux" ]]; then
+        info "Attempting to install espeak-ng..."
+        if command -v apt-get &>/dev/null; then
+            sudo apt-get install -y espeak-ng
+        elif command -v dnf &>/dev/null; then
+            sudo dnf install -y espeak-ng
+        elif command -v pacman &>/dev/null; then
+            sudo pacman -S --noconfirm espeak-ng
+        else
+            die "Cannot auto-install espeak-ng.  Install it with your package manager or from:
+  https://github.com/espeak-ng/espeak-ng/releases"
+        fi
+
+    else
+        die "espeak-ng not found.  Install from: https://github.com/espeak-ng/espeak-ng/releases"
+    fi
+}
+
+# ─── Create virtual environment ───────────────────────────────────────────────
+
+create_venv() {
+    if [[ -d ".venv" ]]; then
+        info ".venv already exists — skipping creation."
+        return
+    fi
+    info "Creating virtual environment..."
+    uv venv --python ">=3.10,<3.14"
+}
+
+# ─── Install Python dependencies ──────────────────────────────────────────────
+
+# Stamp file — prevents recompiling llama-cpp-python on every run.
+# Delete it to force a fresh Metal recompile: rm .venv/.llama_metal
+METAL_STAMP=".venv/.llama_metal"
+
+install_deps() {
+    info "Installing NeuTTS + ONNX + UI dependencies..."
+    uv pip install -e ".[onnx,ui]" \
+        || die "Dependency install failed.  Check the error above."
+
+    if $IS_MACOS_ARM; then
+        # ── Apple Silicon: compile llama-cpp-python with Metal ───────────────
+        if [[ -f "$METAL_STAMP" ]]; then
+            info "llama-cpp-python (Metal) already compiled — skipping."
+        else
+            warn "Compiling llama-cpp-python with Apple Metal support."
+            warn "This is a one-time step and typically takes 5–15 minutes."
+            warn "Ensure Xcode Command Line Tools are installed:  xcode-select --install"
+            echo ""
+
+            CMAKE_ARGS="-DGGML_METAL=ON" \
+            uv pip install \
+                --no-binary llama-cpp-python \
+                --reinstall-package llama-cpp-python \
+                llama-cpp-python \
+            && touch "$METAL_STAMP" \
+            || die "Metal compilation failed.
+  Common fixes:
+    • Install Xcode tools:  xcode-select --install
+    • Ensure CMake is installed:  brew install cmake
+    • Check that Xcode is up to date in the App Store"
+            info "Metal build complete."
+        fi
+
+    else
+        # ── Other platforms ─────────────────────────────────────────────────
+        if command -v nvcc &>/dev/null; then
+            info "CUDA detected — compiling llama-cpp-python with CUDA support..."
+            CMAKE_ARGS="-DGGML_CUDA=ON" \
+            uv pip install --no-binary llama-cpp-python llama-cpp-python \
+            || {
+                warn "CUDA compilation failed — falling back to CPU-only build."
+                uv pip install llama-cpp-python
+            }
+        else
+            info "Installing llama-cpp-python (CPU build)..."
+            uv pip install llama-cpp-python \
+                || die "llama-cpp-python install failed.  Check the error above."
+        fi
+    fi
+}
+
+# ─── Port availability check ─────────────────────────────────────────────────
+
+check_port() {
+    if command -v lsof &>/dev/null; then
+        if lsof -iTCP:"$PORT" -sTCP:LISTEN &>/dev/null 2>&1; then
+            warn "Port $PORT is already in use.  Gradio will pick the next available port."
+        fi
+    fi
+}
+
+# ─── Launch UI ────────────────────────────────────────────────────────────────
+
+launch() {
+    info "Starting NeuTTS UI..."
+    info "Open in your browser: http://${HOST}:${PORT}"
+    echo ""
+
+    .venv/bin/python app.py --host "$HOST" --port "$PORT" "${APP_ARGS[@]+"${APP_ARGS[@]}"}"
+}
+
+# ─── Preflight checks ────────────────────────────────────────────────────────
+
+preflight() {
+    # Must run from the repo root (where app.py lives)
+    if [[ ! -f "app.py" || ! -f "pyproject.toml" ]]; then
+        die "Run this script from the neutts repo root directory."
+    fi
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+    echo ""
+    echo -e "${BLU}NeuTTS — Local Voice Synthesis${NC}"
+    echo    "────────────────────────────────"
+    echo    "Platform: $OS / $ARCH"
+    $IS_MACOS_ARM && echo "Hardware: Apple Silicon (Metal available)"
+    echo ""
+
+    preflight
+    require_uv
+    require_python
+    require_espeak
+    create_venv
+    install_deps
+    check_port
+    launch
+}
+
+main "$@"


### PR DESCRIPTION
- Add _normalize_device() to resolve "auto", "metal", "gpu", "mps",
  "cuda", "cpu" to canonical torch device names; "auto" picks the
  best available backend at runtime
- Fix critical GGUF Metal bug: flash_attn is CUDA-only and must not
  be enabled on Metal — separate use_gpu_layers and use_flash_attn flags
- Use torch.float16 for PyTorch backbone on MPS/CUDA to halve memory
  and improve throughput on Apple Silicon
- Fix encode_reference() tensor device mismatch: move audio tensor to
  codec.device before encoding when using a torch codec on MPS/CUDA
- Allow ONNX decoder with codec_device="mps"; emit a hint when
  CoreMLExecutionProvider is available for Neural Engine acceleration
- Preserve backward compatibility: legacy "gpu" string still works

Pre/post for each issue:

1. Regex: re.findall(pattern, s) compiled every _decode call
   → _SPEECH_TOKEN_RE = re.compile(...) at module level, reused everywhere

2. Special token IDs: 5x convert_tokens_to_ids + tokenizer.encode(chat)
   called on every _apply_chat_template / _infer_torch invocation
   → all cached as self._tok_* and self._prompt_template_ids at load time

3. max_length=self.max_context silently truncated output when prompt was long
   → max_new_tokens=self.max_context; always generates the full token budget

4. Streaming token cache: list[str] of "<|speech_N|>" fragments, "".join()
   + regex on every chunk window (O(n) growing string each call)
   → list[int] of raw codes; single regex.search per incoming token,
   then direct slice to _decode_from_ids — no string building or regex

5. Watermark applied to every overlapping decode window inside the loop,
   watermarking the same audio region multiple times before discarding edges
   → watermark applied once to the final processed_recon slice being yielded

6. temperature and top_k hardcoded to 1.0 / 50 in all three inference paths
   → exposed on infer() and infer_stream(), threaded through to all backends

app.py:
- Gradio Blocks UI with model settings panel and I/O panel
- Singleton TTS instance; re-uses loaded model when settings unchanged
- Reference encoding cache keyed by file path (avoids re-encoding same speaker)
- ONNX decoder fallback: if codec has no encode_code, loads a separate NeuCodec
  encoder lazily and caches it
- Validates text (empty, >500 chars), reference audio (3-20s duration, readable),
  and reference transcript before calling the model
- Live char counter and audio duration feedback on change events
- Streaming mode via generator yield — audio grows in real-time for GGUF models
- Falls back to non-streaming silently when a torch (non-GGUF) model is loaded
- RTF + elapsed time stats on every yielded chunk
- Hardware-aware defaults: selects metal/cuda/cpu and matching backbone at startup
- Built-in sample speakers (Dave, Greta, Jo, Juliette, Mateo) in quick-start dropdown
- --host / --port / --share CLI args

run.sh:
- Installs uv if missing (curl installer), then uses uv throughout
- Installs Python 3.10-3.13 via uv if not present
- Checks / installs espeak-ng (Homebrew on macOS, apt/dnf/pacman on Linux)
- Creates .venv with uv venv; skips if it already exists
- macOS arm64: compiles llama-cpp-python from source with -DGGML_METAL=ON;
  stamp file (.venv/.llama_metal) prevents recompilation on subsequent runs
- Linux + CUDA nvcc present: compiles with -DGGML_CUDA=ON, falls back to CPU
- Checks for port conflicts before launching
- Preflight guard: refuses to run outside the repo root
- All errors use die() with actionable remediation instructions

pyproject.toml:
- Add ui = ["gradio>=4.0.0"] optional dependency
- Add gradio to the all extra

