### PR TITLE
feat: declare Python 3.14 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ We include benchmarks on four devices: Galaxy A25 5G, AMD Ryzen 9HX 370, iMac M4
 > We have added a [streaming example](examples/basic_streaming_example.py) using the `llama-cpp-python` library as well as a [finetuning script](examples/finetune.py). For finetuning, please refer to the [finetune guide](TRAINING.md) for more details.
 
 1. **Install NeuTTS**
+
+   - Python 3.10-3.14 is supported. On Python 3.14, `llama-cpp-python` may need to build from source.
+
    ```bash
    pip install neutts
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "NeuTTS - a package for text-to-speech generation using Neuphonic's TTS models."
 readme = "README.md"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.10, <3.15"
 dependencies = [
     "librosa==0.11.0",
     "neucodec>=0.0.4",


### PR DESCRIPTION
## Summary

Bump `requires-python` to `>=3.10, <3.15` and add a one-line README note on Python 3.14 to close #124. The current `<3.14` constraint blocks install on 3.14 without any technical reason; nothing in this package uses 3.14-incompatible APIs.

## Why this matters

#124 asks for 3.14 support. The only hard blocker would be a transitive dep that doesn't ship 3.14 wheels; `llama-cpp-python` may need to build from source on 3.14 until they publish wheels, so the README adds a one-line caveat next to the install instructions. Everything else in the dep tree (librosa, neucodec, soundfile, transformers) already ships 3.14 wheels.

Closes #124
