### PR TITLE
refactor: split phonemization out of finetune script

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -11,7 +11,13 @@ You can prepare your own dataset by following these steps:
 
 1. Encode your audio files using the [NeuCodec](https://huggingface.co/neuphonic/neucodec) model into a format similar to the [Emilia-YODAS dataset](https://huggingface.co/datasets/neuphonic/emilia-yodas-english-neucodec).
 2. Setup your configuration file similar to the [example config](/examples/finetune_config.yaml).
-3. Check and modify the phonemizer and the tokenizer in the script such that they suit your dataset/task. See [the phonemizer documentation](https://bootphon.github.io/phonemizer/api_reference.html#phonemizer.backend.espeak.espeak.EspeakBackend) for phonemizer arguments.
+3. Phonemize your text once before training so your dataset has a `phones` column. For a Hugging Face dataset, run:
+
+    ```bash
+    python examples/phonemize_dataset.py DATASET_NAME ./phonemized_dataset --language en-us
+    ```
+
+    Replace `DATASET_NAME`, the output path, and `--language` with values for your dataset. Use `python examples/phonemize_dataset.py parquet ./phonemized_dataset --data_files path/to/data.parquet --language en-us` for local parquet files. See [the phonemizer documentation](https://bootphon.github.io/phonemizer/api_reference.html#phonemizer.backend.espeak.espeak.EspeakBackend) for supported eSpeak language codes.
 4. Run the finetuning script with your dataset and configuration file. To do this, navigate to the base directory of your cloned repo in the terminal and run:
 
     ```bash
@@ -20,10 +26,14 @@ You can prepare your own dataset by following these steps:
 
     replacing the argument with the path to your own config file if needed.
 
+The finetuning script reads `phones` directly when the column is present. Datasets without `phones` still work through inline phonemization for compatibility, but preprocessing first is recommended.
+
 # Finetuning config
 
 An example finetuning config lives in `examples/finetune_config.yaml`.
 
+- Set `dataset_name`, `dataset_split`, and `dataset_from_disk` to point at your training dataset. For the local output above, use `dataset_name: "./phonemized_dataset"` and `dataset_from_disk: true`.
+- Set `language` to the eSpeak language code that matches your dataset, for example `en-us`, `de`, `fr-fr`, or `es`.
 - In the past we've found a learning rate of `1e-5` to `4e-5` to have worked well for finetuning depending on the size of the dataset.
 - We generally find that you do not need many steps for finetuning. For example, for a dataset of 10 hours, 1000 to 2000 steps is often sufficient.
 - A warmup ratio as well as different learning rate schedulers can be experimented with to see what works best for your dataset.

--- a/examples/finetune.py
+++ b/examples/finetune.py
@@ -3,7 +3,7 @@ import warnings
 import re
 import os
 import torch
-import phonemizer
+from phonemizer.backend import EspeakBackend
 
 from fire import Fire
 from omegaconf import OmegaConf
@@ -16,13 +16,24 @@ from transformers import (
     default_data_collator,
 )
 from loguru import logger as LOGGER
-from datasets import load_dataset
+from datasets import load_dataset, load_from_disk
 
 warnings.filterwarnings("ignore")
 
 
 ACRONYM = re.compile(r"(?:[a-zA-Z]\.){2,}")
 ACRONYM_NO_PERIOD = re.compile(r"(?:[A-Z]){2,}")
+DEFAULT_LANGUAGE = "en-us"
+
+
+def build_phonemizer(language):
+    return EspeakBackend(
+        language=language,
+        preserve_punctuation=True,
+        with_stress=True,
+        words_mismatch="ignore",
+        language_switch="remove-flags",
+    )
 
 
 def data_filter(sample):
@@ -46,7 +57,38 @@ def data_filter(sample):
     return True
 
 
-def preprocess_sample(sample, tokenizer, max_len, g2p):
+def normalize_phones(phones):
+    if isinstance(phones, list):
+        phones = " ".join(str(phone) for phone in phones)
+
+    return " ".join(str(phones).split())
+
+
+def get_phones(sample, g2p):
+    if "phones" in sample and sample["phones"]:
+        return normalize_phones(sample["phones"])
+
+    if g2p is None:
+        LOGGER.warning(f"⚠️ Missing phones for sample: {sample.get('__key__', '<unknown>')}")
+        return None
+
+    text = sample.get("text")
+    if not text:
+        LOGGER.warning(f"⚠️ Missing text for sample: {sample.get('__key__', '<unknown>')}")
+        return None
+
+    phones = g2p.phonemize([text])
+    if not phones or not phones[0]:
+        LOGGER.warning(
+            f"⚠️ Empty phonemization output for sample: {sample.get('__key__', '<unknown>')} "
+            f"text={text}"
+        )
+        return None
+
+    return normalize_phones(phones[0])
+
+
+def preprocess_sample(sample, tokenizer, max_len, g2p=None):
 
     # get special tokens
     speech_gen_start = tokenizer.convert_tokens_to_ids("<|SPEECH_GENERATION_START|>")
@@ -54,18 +96,10 @@ def preprocess_sample(sample, tokenizer, max_len, g2p):
 
     # unpack sample
     vq_codes = sample["codes"]
-    text = sample["text"]
 
-    # phonemize
-    phones = g2p.phonemize([text])
-
-    # SAFE CHECK
-    if not phones or not phones[0]:
-        LOGGER.warning(f"⚠️ Empty phonemization output for sample: {sample['__key__']} text={text}")
+    phones = get_phones(sample, g2p)
+    if not phones:
         return None
-
-    phones = phones[0].split()
-    phones = " ".join(phones)
 
     codes_str = "".join([f"<|speech_{i}|>" for i in vq_codes])
 
@@ -109,17 +143,37 @@ def main(config_fpath: str):
 
     restore_from = config.restore_from
 
+    language = config.get("language", DEFAULT_LANGUAGE)
+    if "language" not in config:
+        LOGGER.warning(
+            f"No `language` found in config; defaulting to `{DEFAULT_LANGUAGE}`. "
+            "Add `language` to your finetune config to control phonemization."
+        )
+
     print(f"Loading checkpoint from {restore_from}")
     tokenizer = AutoTokenizer.from_pretrained(restore_from)
     model = AutoModelForCausalLM.from_pretrained(restore_from, torch_dtype="auto")
 
-    g2p = phonemizer.backend.EspeakBackend(
-        language="en-us",
-        preserve_punctuation=True,
-        with_stress=True,
-        words_mismatch="ignore",
-        language_switch="remove-flags",
-    )
+    dataset_name = config.get("dataset_name", "neuphonic/emilia-yodas-english-neucodec")
+    dataset_split = config.get("dataset_split", "train[:2000]")
+    dataset_from_disk = config.get("dataset_from_disk", False)
+
+    if dataset_from_disk:
+        emilia_dataset = load_from_disk(dataset_name)
+        if dataset_split and hasattr(emilia_dataset, "keys"):
+            emilia_dataset = emilia_dataset[dataset_split]
+    else:
+        emilia_dataset = load_dataset(dataset_name, split=dataset_split)
+
+    g2p = None
+    if "phones" not in emilia_dataset.column_names:
+        LOGGER.warning(
+            "Dataset has no `phones` column; phonemizing `text` inline is deprecated. "
+            "Run `python examples/phonemize_dataset.py ...` once to create a pre-phonemized "
+            "dataset before finetuning."
+        )
+        g2p = build_phonemizer(language)
+
     partial_preprocess = partial(
         preprocess_sample,
         tokenizer=tokenizer,
@@ -127,12 +181,13 @@ def main(config_fpath: str):
         g2p=g2p,
     )
 
-    emilia_dataset = load_dataset(
-        "neuphonic/emilia-yodas-english-neucodec",
-        split="train[:2000]",
-    )
-    emilia_dataset = emilia_dataset.filter(data_filter).map(
-        partial_preprocess, remove_columns=["text", "codes"]
+    if "text" in emilia_dataset.column_names:
+        emilia_dataset = emilia_dataset.filter(data_filter)
+    else:
+        LOGGER.warning("Dataset has no `text` column; skipping text-based filtering.")
+
+    emilia_dataset = emilia_dataset.map(
+        partial_preprocess, remove_columns=emilia_dataset.column_names
     )
 
     training_args = TrainingArguments(

--- a/examples/finetune_config.yaml
+++ b/examples/finetune_config.yaml
@@ -2,6 +2,12 @@
 restore_from: "neuphonic/neutts-air"
 save_root: "/data"
 run_name: "neutts-finetune"
+language: "en-us"
+
+# dataset info
+dataset_name: "neuphonic/emilia-yodas-english-neucodec"
+dataset_split: "train[:2000]"
+dataset_from_disk: false
 
 # model info
 codebook_size: 65536 # xcodec

--- a/examples/phonemize_dataset.py
+++ b/examples/phonemize_dataset.py
@@ -1,0 +1,74 @@
+from functools import partial
+
+from datasets import load_dataset, load_from_disk
+from fire import Fire
+from phonemizer.backend import EspeakBackend
+
+
+def build_phonemizer(language):
+    return EspeakBackend(
+        language=language,
+        preserve_punctuation=True,
+        with_stress=True,
+        words_mismatch="ignore",
+        language_switch="remove-flags",
+    )
+
+
+def normalize_phones(phones):
+    return " ".join(phones.split())
+
+
+def phonemize_sample(sample, g2p, text_column, phones_column):
+    text = sample[text_column]
+    phones = g2p.phonemize([text])
+    sample[phones_column] = normalize_phones(phones[0]) if phones and phones[0] else ""
+    return sample
+
+
+def main(
+    dataset: str,
+    output_path: str = None,
+    split: str = "train",
+    language: str = "en-us",
+    text_column: str = "text",
+    phones_column: str = "phones",
+    data_files: str = None,
+    push_to_hub: str = None,
+    load_from_disk_path: bool = False,
+    num_proc: int = None,
+):
+    if output_path is None and push_to_hub is None:
+        raise ValueError("Provide `output_path` to save locally or `push_to_hub` to upload.")
+
+    if load_from_disk_path:
+        phonemized_dataset = load_from_disk(dataset)
+        if split and hasattr(phonemized_dataset, "keys"):
+            phonemized_dataset = phonemized_dataset[split]
+    else:
+        phonemized_dataset = load_dataset(dataset, split=split, data_files=data_files)
+
+    if text_column not in phonemized_dataset.column_names:
+        raise ValueError(f"Dataset must contain a `{text_column}` column.")
+
+    g2p = build_phonemizer(language)
+    phonemized_dataset = phonemized_dataset.map(
+        partial(
+            phonemize_sample,
+            g2p=g2p,
+            text_column=text_column,
+            phones_column=phones_column,
+        ),
+        num_proc=num_proc,
+        desc=f"Phonemizing `{text_column}` to `{phones_column}`",
+    )
+
+    if output_path:
+        phonemized_dataset.save_to_disk(output_path)
+
+    if push_to_hub:
+        phonemized_dataset.push_to_hub(push_to_hub)
+
+
+if __name__ == "__main__":
+    Fire(main)


### PR DESCRIPTION
## Summary

The fine-tune script ran `phonemizer.EspeakBackend` inside `preprocess_sample` for every example, which:

- coupled the dataset loader to the phonemizer install
- ran phonemization on every training step rerun (slow)
- mixed two concerns (dataset prep vs training)

Split the phonemizer into a separate `examples/phonemize_dataset.py` helper that writes a `phones` column once. The fine-tune script now reads `phones` directly when present and falls back to inline phonemization for backward compatibility.

Configuration:
- `finetune_config.yaml` gets a `language` setting (defaults to `en-us`) so the inline-fallback knows which eSpeak language to use.
- Optional `dataset_from_disk` flag to point at the preprocessed local dataset.

TRAINING.md adds the preprocessing step and a note that already-phonemized datasets skip the inline path.

## Why this matters

#93 (filed by @Cyrilvallez) asks for the phonemizer to come out of the fine-tune script. Two-step is the standard HF preprocessing pattern, and it lets users without `espeak` installed still train as long as they preprocess once. The inline fallback keeps backward compat: existing user configs/datasets that don't have a `phones` column keep working unchanged.

This is a refactor + small docs update; no maintainer signal on the issue, so framing the change as opt-in keeps the risk surface narrow.

Closes #93
